### PR TITLE
perf: clean code for performance

### DIFF
--- a/files/httpRequest.tsf
+++ b/files/httpRequest.tsf
@@ -6,7 +6,6 @@ const Http = {
   async getRequest(
     url: string,
     queryParams: any | undefined,
-    requestBody: any | undefined,
     configOverride?: AxiosRequestConfig,
   ): Promise<AxiosResponse<any>> {
     try {
@@ -62,7 +61,6 @@ const Http = {
   async deleteRequest(
     url: string,
     queryParams: any | undefined,
-    requestBody: any | undefined,
     configOverride?: AxiosRequestConfig,
   ): Promise<AxiosResponse<any>> {
     try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-typescript",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A auto generate typescript code from swagger",
   "main": "lib/index.js",
   "scripts": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,7 +49,7 @@ function generateServiceName(endPoint: string): string {
     return pointArray.join("");
   }
 
-  let name = replaceWithUpper(
+  const name = replaceWithUpper(
     replaceWithUpper(replaceWithUpper(endPoint, "/"), "{"),
     "}",
   );


### PR DESCRIPTION
hi, deleteRequest and getRequest do not need to requestBody because they do not use it. for this reason, i deleted them. and replaceWithUpper does not need that let because elsewhere its information has not changed.