### PR TITLE
Implementing axios interceptors

### DIFF
--- a/files/config.tsf
+++ b/files/config.tsf
@@ -38,7 +38,20 @@ function getAxiosInstance(): AxiosInstance {
       async (response) => {
         return response;
       },
-      (error) => {
+      (error: AxiosError) => {
+        if (error.response) {
+          Promise.reject(new SwaggerError({
+            message: error.response.data,
+            status: error.response.status,
+            response: error.response,
+          }));
+        }
+      
+        if (error.isAxiosError) {
+          Promise.reject(new SwaggerError({
+            message: "noInternetConnection",
+          }));
+        }
         Promise.reject(error);
       },
     );
@@ -47,31 +60,13 @@ function getAxiosInstance(): AxiosInstance {
   return axiosInstance;
 }
 
-function errorCatch(error: AxiosError): any {
-  if (error.response) {
-    throw new Exception({
-      message: error.response.data,
-      status: error.response.status,
-      response: error.response,
-    });
-  }
-
-  if (error.isAxiosError) {
-    throw new Exception({
-      message: "noInternetConnection",
-    });
-  }
-
-  throw error;
-}
-
 interface ErrorParam {
   message: string;
   status?: number;
   response?: AxiosResponse;
 }
 
-class Exception extends Error {
+class SwaggerError extends Error {
   message: string;
   status?: number;
   response?: AxiosResponse;
@@ -86,8 +81,6 @@ class Exception extends Error {
   isApiException = true;
 }
 
-// export type SwaggerResponse<R> = R;
-
 export interface SwaggerResponse<R> extends AxiosResponse<R> {}
 
 async function responseWrapper(
@@ -98,8 +91,6 @@ async function responseWrapper(
 
 export {
   getBaseConfig,
-  errorCatch,
-  Exception,
   responseWrapper,
   getAxiosInstance,
 };

--- a/files/config.tsf
+++ b/files/config.tsf
@@ -81,15 +81,6 @@ class SwaggerError extends Error {
   isApiException = true;
 }
 
-export interface SwaggerResponse<R> extends AxiosResponse<R> {}
-
-async function responseWrapper(
-  response: AxiosResponse<any>,
-): Promise<SwaggerResponse<any>> {
-  return response;
-}
-
 export {
-  responseWrapper,
   getAxiosInstance,
 };

--- a/files/config.tsf
+++ b/files/config.tsf
@@ -5,6 +5,7 @@ import Axios, {
   AxiosResponse,
   AxiosInstance,
 } from "axios";
+import qs from "qs";
 
 const baseConfig: AxiosRequestConfig = {
   baseURL: "",
@@ -13,7 +14,8 @@ const baseConfig: AxiosRequestConfig = {
     Accept: "application/json",
     "Content-Type": "application/json-patch+json",
   },
-}
+  paramsSerializer: (param) => qs.stringify(param, { indices: false }),
+};
 
 let axiosInstance: AxiosInstance;
 

--- a/files/config.tsf
+++ b/files/config.tsf
@@ -1,5 +1,10 @@
 // Please add your custom config
-import { AxiosRequestConfig, AxiosError, AxiosResponse } from "axios";
+import Axios, {
+  AxiosRequestConfig,
+  AxiosError,
+  AxiosResponse,
+  AxiosInstance,
+} from "axios";
 
 async function getBaseConfig(): Promise<AxiosRequestConfig> {
   return {
@@ -10,6 +15,36 @@ async function getBaseConfig(): Promise<AxiosRequestConfig> {
       "Content-Type": "application/json-patch+json",
     },
   };
+}
+
+let axiosInstance: AxiosInstance;
+
+function getAxiosInstance(): AxiosInstance {
+  if (!axiosInstance) {
+    axiosInstance = Axios.create();
+    axiosInstance.interceptors.request.use(
+      async (request) => {
+        if (request.url?.includes("/")) {
+          request.headers.authorization = ""; // Add authorization header conditionaly.
+        }
+        return request;
+      },
+      (error) => {
+        Promise.reject(error);
+      },
+    );
+
+    axiosInstance.interceptors.response.use(
+      async (response) => {
+        return response;
+      },
+      (error) => {
+        Promise.reject(error);
+      },
+    );
+  }
+
+  return axiosInstance;
 }
 
 function errorCatch(error: AxiosError): any {
@@ -61,4 +96,10 @@ async function responseWrapper(
   return response;
 }
 
-export { getBaseConfig, errorCatch, Exception, responseWrapper };
+export {
+  getBaseConfig,
+  errorCatch,
+  Exception,
+  responseWrapper,
+  getAxiosInstance,
+};

--- a/files/config.tsf
+++ b/files/config.tsf
@@ -23,11 +23,11 @@ function getAxiosInstance(): AxiosInstance {
   if (!axiosInstance) {
     axiosInstance = Axios.create();
     axiosInstance.interceptors.request.use(
-      async (request) => {
-        if (request.url?.includes("/")) {
-          request.headers.authorization = ""; // Add authorization header conditionaly.
+      async (requestConfig) => {
+        if (requestConfig.url?.includes("/")) {
+          requestConfig.headers.authorization = ""; // Add authorization header conditionaly.
         }
-        return request;
+        return requestConfig;
       },
       (error) => {
         Promise.reject(error);

--- a/files/config.tsf
+++ b/files/config.tsf
@@ -6,27 +6,27 @@ import Axios, {
   AxiosInstance,
 } from "axios";
 
-async function getBaseConfig(): Promise<AxiosRequestConfig> {
-  return {
-    baseURL: "",
-    headers: {
-      "Content-Encoding": "UTF-8",
-      Accept: "application/json",
-      "Content-Type": "application/json-patch+json",
-    },
-  };
+const baseConfig: AxiosRequestConfig = {
+  baseURL: "",
+  headers: {
+    "Content-Encoding": "UTF-8",
+    Accept: "application/json",
+    "Content-Type": "application/json-patch+json",
+  },
 }
 
 let axiosInstance: AxiosInstance;
 
 function getAxiosInstance(): AxiosInstance {
   if (!axiosInstance) {
-    axiosInstance = Axios.create();
+    axiosInstance = Axios.create(baseConfig);
     axiosInstance.interceptors.request.use(
       async (requestConfig) => {
+        /*
         if (requestConfig.url?.includes("/")) {
           requestConfig.headers.authorization = ""; // Add authorization header conditionaly.
         }
+        */
         return requestConfig;
       },
       (error) => {
@@ -90,7 +90,6 @@ async function responseWrapper(
 }
 
 export {
-  getBaseConfig,
   responseWrapper,
   getAxiosInstance,
 };

--- a/files/config.tsf
+++ b/files/config.tsf
@@ -24,9 +24,9 @@ function getAxiosInstance(): AxiosInstance {
     axiosInstance = Axios.create(baseConfig);
     axiosInstance.interceptors.request.use(
       async (requestConfig) => {
-        /*
+        /* Example on how to add authorization to specific paths
         if (requestConfig.url?.includes("/")) {
-          requestConfig.headers.authorization = ""; // Add authorization header conditionaly.
+          requestConfig.headers.authorization = "";
         }
         */
         return requestConfig;
@@ -37,8 +37,14 @@ function getAxiosInstance(): AxiosInstance {
     );
 
     axiosInstance.interceptors.response.use(
-      async (response) => {
+      async (response: AxiosResponse) => {
         return response;
+        /* Example on response manipulation
+        const swaggerResponse: SwaggerResponse = {
+          ...response
+        };        
+        return swaggerResponse;
+        */
       },
       (error: AxiosError) => {
         if (error.response) {
@@ -82,6 +88,8 @@ class SwaggerError extends Error {
 
   isApiException = true;
 }
+
+export interface SwaggerResponse<R> extends AxiosResponse<R> {}
 
 export {
   getAxiosInstance,

--- a/files/httpRequest.tsf
+++ b/files/httpRequest.tsf
@@ -1,8 +1,8 @@
 // AUTO_GENERATED Do not change this file directly change config.ts file instead
-import Axios, { AxiosRequestConfig, AxiosResponse } from "axios";
+import { AxiosRequestConfig, AxiosResponse } from "axios";
 //@ts-ignore
 import qs from "qs";
-import { getBaseConfig, errorCatch } from "./config";
+import { getBaseConfig, errorCatch, getAxiosInstance } from "./config";
 
 function paramsSerializer(param: any) {
   return qs.stringify(param, {
@@ -19,7 +19,7 @@ const Http = {
     configOverride?: AxiosRequestConfig,
   ): Promise<AxiosResponse<any>> {
     try {
-      return await Axios.get(
+      return await getAxiosInstance().get(
         url,
         overrideConfig(await getBaseConfig(), {
           paramsSerializer,
@@ -38,7 +38,7 @@ const Http = {
     configOverride?: AxiosRequestConfig,
   ): Promise<AxiosResponse<any>> {
     try {
-      return await Axios.post(
+      return await getAxiosInstance().post(
         url,
         requestBody,
         overrideConfig(await getBaseConfig(), {
@@ -58,7 +58,7 @@ const Http = {
     configOverride?: AxiosRequestConfig,
   ): Promise<AxiosResponse<any>> {
     try {
-      return await Axios.put(
+      return await getAxiosInstance().put(
         url,
         requestBody,
         overrideConfig(await getBaseConfig(), {
@@ -79,7 +79,7 @@ const Http = {
     configOverride?: AxiosRequestConfig,
   ): Promise<AxiosResponse<any>> {
     try {
-      return await Axios.delete(
+      return await getAxiosInstance().delete(
         url,
         overrideConfig(await getBaseConfig(), {
           paramsSerializer,

--- a/files/httpRequest.tsf
+++ b/files/httpRequest.tsf
@@ -4,7 +4,7 @@ import { AxiosRequestConfig, AxiosResponse } from "axios";
 
 import { getAxiosInstance } from "./config";
 
-const Http = {
+export const Http = {
   async getRequest(
     url: string,
     queryParams: any | undefined,
@@ -66,19 +66,3 @@ const Http = {
     );
   },
 };
-
-function overrideConfig(
-  config?: AxiosRequestConfig,
-  configOverride?: AxiosRequestConfig,
-): AxiosRequestConfig {
-  return {
-    ...config,
-    ...configOverride,
-    headers: {
-      ...config?.headers,
-      ...configOverride?.headers,
-    },
-  };
-}
-
-export { Http, overrideConfig };

--- a/files/httpRequest.tsf
+++ b/files/httpRequest.tsf
@@ -2,7 +2,7 @@
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 //@ts-ignore
 import qs from "qs";
-import { getBaseConfig, errorCatch, getAxiosInstance } from "./config";
+import { getBaseConfig, getAxiosInstance } from "./config";
 
 function paramsSerializer(param: any) {
   return qs.stringify(param, {
@@ -18,18 +18,14 @@ const Http = {
     requestBody: undefined,
     configOverride?: AxiosRequestConfig,
   ): Promise<AxiosResponse<any>> {
-    try {
-      return await getAxiosInstance().get(
-        url,
-        overrideConfig(await getBaseConfig(), {
-          paramsSerializer,
-          params: queryParams,
-          ...configOverride,
-        }),
-      );
-    } catch (error) {
-      return errorCatch(error);
-    }
+    return getAxiosInstance().get(
+      url,
+      overrideConfig(await getBaseConfig(), {
+        paramsSerializer,
+        params: queryParams,
+        ...configOverride,
+      }),
+    );
   },
   async postRequest(
     url: string,
@@ -37,19 +33,15 @@ const Http = {
     requestBody: any | undefined,
     configOverride?: AxiosRequestConfig,
   ): Promise<AxiosResponse<any>> {
-    try {
-      return await getAxiosInstance().post(
-        url,
-        requestBody,
-        overrideConfig(await getBaseConfig(), {
-          paramsSerializer,
-          params: queryParams,
-          ...configOverride,
-        }),
-      );
-    } catch (error) {
-      return errorCatch(error);
-    }
+    return getAxiosInstance().post(
+      url,
+      requestBody,
+      overrideConfig(await getBaseConfig(), {
+        paramsSerializer,
+        params: queryParams,
+        ...configOverride,
+      }),
+    );
   },
   async putRequest(
     url: string,
@@ -57,19 +49,15 @@ const Http = {
     requestBody: any | undefined,
     configOverride?: AxiosRequestConfig,
   ): Promise<AxiosResponse<any>> {
-    try {
-      return await getAxiosInstance().put(
-        url,
-        requestBody,
-        overrideConfig(await getBaseConfig(), {
-          paramsSerializer,
-          params: queryParams,
-          ...configOverride,
-        }),
-      );
-    } catch (error) {
-      return errorCatch(error);
-    }
+    return getAxiosInstance().put(
+      url,
+      requestBody,
+      overrideConfig(await getBaseConfig(), {
+        paramsSerializer,
+        params: queryParams,
+        ...configOverride,
+      }),
+    );
   },
   async deleteRequest(
     url: string,
@@ -78,18 +66,14 @@ const Http = {
     requestBody: undefined,
     configOverride?: AxiosRequestConfig,
   ): Promise<AxiosResponse<any>> {
-    try {
-      return await getAxiosInstance().delete(
-        url,
-        overrideConfig(await getBaseConfig(), {
-          paramsSerializer,
-          params: queryParams,
-          ...configOverride,
-        }),
-      );
-    } catch (error) {
-      return errorCatch(error);
-    }
+    return getAxiosInstance().delete(
+      url,
+      overrideConfig(await getBaseConfig(), {
+        paramsSerializer,
+        params: queryParams,
+        ...configOverride,
+      }),
+    );
   },
 };
 

--- a/files/httpRequest.tsf
+++ b/files/httpRequest.tsf
@@ -1,14 +1,8 @@
 // AUTO_GENERATED Do not change this file directly change config.ts file instead
 import { AxiosRequestConfig, AxiosResponse } from "axios";
 //@ts-ignore
-import qs from "qs";
-import { getBaseConfig, getAxiosInstance } from "./config";
 
-function paramsSerializer(param: any) {
-  return qs.stringify(param, {
-    indices: false,
-  });
-}
+import { getAxiosInstance } from "./config";
 
 const Http = {
   async getRequest(
@@ -20,11 +14,10 @@ const Http = {
   ): Promise<AxiosResponse<any>> {
     return getAxiosInstance().get(
       url,
-      overrideConfig(await getBaseConfig(), {
-        paramsSerializer,
+      {
         params: queryParams,
         ...configOverride,
-      }),
+      },
     );
   },
   async postRequest(
@@ -36,11 +29,10 @@ const Http = {
     return getAxiosInstance().post(
       url,
       requestBody,
-      overrideConfig(await getBaseConfig(), {
-        paramsSerializer,
+      {
         params: queryParams,
         ...configOverride,
-      }),
+      },
     );
   },
   async putRequest(
@@ -52,11 +44,10 @@ const Http = {
     return getAxiosInstance().put(
       url,
       requestBody,
-      overrideConfig(await getBaseConfig(), {
-        paramsSerializer,
+      {
         params: queryParams,
         ...configOverride,
-      }),
+      },
     );
   },
   async deleteRequest(
@@ -68,11 +59,10 @@ const Http = {
   ): Promise<AxiosResponse<any>> {
     return getAxiosInstance().delete(
       url,
-      overrideConfig(await getBaseConfig(), {
-        paramsSerializer,
+      {
         params: queryParams,
         ...configOverride,
-      }),
+      },
     );
   },
 };

--- a/src/generateApis.ts
+++ b/src/generateApis.ts
@@ -71,7 +71,7 @@ export const ${serviceName} = async (
                   )},`
                 : ""
             }configOverride?:AxiosRequestConfig
-): Promise<AxiosResponse<${responses ? getTsType(responses) : "any"}>> => {
+): Promise<SwaggerResponse<${responses ? getTsType(responses) : "any"}>> => {
   ${
     deprecated
       ? `
@@ -91,15 +91,15 @@ export const ${serviceName} = async (
     },
     ${queryParamsTypeName ? "queryParams" : "undefined"},
     ${requestBody ? "requestBody" : "undefined"},
-    {
+    overrideConfig({
       headers: {
         "Content-Type": "${contentType}",
         Accept: "${accept}",
         ${headerParams ? "...headerParams," : ""}
       },
-      ...configOverride,
     },
-  )
+    configOverride,
+  ))
 }
 `
           );

--- a/src/generateApis.ts
+++ b/src/generateApis.ts
@@ -71,7 +71,7 @@ export const ${serviceName} = async (
                   )},`
                 : ""
             }configOverride?:AxiosRequestConfig
-): Promise<SwaggerResponse<${responses ? getTsType(responses) : "any"}>> => {
+): Promise<AxiosResponse<${responses ? getTsType(responses) : "any"}>> => {
   ${
     deprecated
       ? `
@@ -83,7 +83,7 @@ export const ${serviceName} = async (
   }`
       : ""
   }
-  return responseWrapper(await Http.${method}Request(
+  return Http.${method}Request(
     ${
       pathParamsRefString
         ? `template("${endPoint}",${pathParamsRefString})`
@@ -99,7 +99,7 @@ export const ${serviceName} = async (
       },
       ...configOverride,
     },
-  ))
+  )
 }
 `
           );

--- a/src/generateApis.ts
+++ b/src/generateApis.ts
@@ -91,15 +91,14 @@ export const ${serviceName} = async (
     },
     ${queryParamsTypeName ? "queryParams" : "undefined"},
     ${requestBody ? "requestBody" : "undefined"},
-    overrideConfig({
-        headers: {
-          "Content-Type": "${contentType}",
-          Accept: "${accept}",
-          ${headerParams ? "...headerParams," : ""}
-        },
+    {
+      headers: {
+        "Content-Type": "${contentType}",
+        Accept: "${accept}",
+        ${headerParams ? "...headerParams," : ""}
       },
-      configOverride,
-    )
+      ...configOverride,
+    },
   ))
 }
 `

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -10,11 +10,26 @@ const CONFIG = readFileSync(
 
 const SERVICE_BEGINNING = `
 // AUTO_GENERATED Do not change this file directly change config.ts file instead
-import { AxiosRequestConfig, AxiosResponse } from "axios";
+import { AxiosRequestConfig } from "axios";
+import { SwaggerResponse } from "./config";
 import { Http } from "./httpRequest";
 
 //@ts-ignore
 const __DEV__ = process.env.NODE_ENV !== "production";
+
+function overrideConfig(
+  config?: AxiosRequestConfig,
+  configOverride?: AxiosRequestConfig,
+): AxiosRequestConfig {
+  return {
+    ...config,
+    ...configOverride,
+    headers: {
+      ...config?.headers,
+      ...configOverride?.headers,
+    },
+  };
+}
 
 function template(path: string, obj: { [x: string]: any } = {}) {
     Object.keys(obj).forEach((key) => {

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -10,9 +10,8 @@ const CONFIG = readFileSync(
 
 const SERVICE_BEGINNING = `
 // AUTO_GENERATED Do not change this file directly change config.ts file instead
-import { AxiosRequestConfig } from "axios";
-import { SwaggerResponse, responseWrapper } from "./config";
-import { Http, overrideConfig } from "./httpRequest";
+import { AxiosRequestConfig, AxiosResponse } from "axios";
+import { Http } from "./httpRequest";
 
 //@ts-ignore
 const __DEV__ = process.env.NODE_ENV !== "production";


### PR DESCRIPTION
This allows developers to inject (or leave out) tokens based on url they are fetching

one example is that you do not want to add bearer token authentication on your `/authenticate` endpoint, but it is required on all others.

One could also add special handling when 403 is received, f.ex. re-authentication, and re-sending the request afterwards automatically
(Idea from https://thedutchlab.com/blog/using-axios-interceptors-for-refreshing-your-api-token) 