### PR TITLE
feat: add includes and excludes config options

### DIFF
--- a/__tests__/main/__snapshots__/excludes.test.mjs.snap
+++ b/__tests__/main/__snapshots__/excludes.test.mjs.snap
@@ -1,0 +1,20628 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`excludes post methods generate Code 1`] = `
+"
+//@ts-nocheck
+/**
+* AUTO_GENERATED Do not change this file directly, use config.ts file instead
+*
+* @version 6
+*/
+
+import type { AxiosRequestConfig } from \\"axios\\";
+import type { SwaggerResponse } from \\"./config\\";
+import { Http } from \\"./httpRequest\\";
+//@ts-ignore
+import qs from \\"qs\\";
+import type { DeleteBusinessUserConnectionInvitationIdRemoveQueryParams, GetBusinessUserConnectionQueryParams, GetBusinessUserConnectionActiveQueryParams, GetBusinessUserConnectionConnectionIdEpayQueryParams, GetEpayRequestQueryParams, GetEpayRequestExcelQueryParams, GetEpayRequestForMeQueryParams, GetEpayRequestUserWalletIdCommissionQueryParams, GetEpayRequestCountQueryParams, GetEpayRequestReportQueryParams, GetEpayRequestForMeCountQueryParams, GetEpayRequestForMeReportQueryParams, GetEpayRequestPosQrAccountNumberQueryParams, GetGroupTransferCommissionQueryParams, GetIntegrationQueryParams, GetKpiLastQueryParams, GetKpiCurrentQueryParams, GetKpiQueryParams, GetNotificationUnreadQueryParams, GetPosAccountNumberQueryParams, GetResellerUserIntroducedQueryParams, GetResellerUserDashboardCommissionSumQueryParams, GetResellerUserDashboardCommissionReportQueryParams, GetResellerUserDashboardLinksCountQueryParams, GetResellerUserDashboardLinksReportQueryParams, GetResellerUserDashboardLinksPaidCountQueryParams, GetResellerUserDashboardLinksPaidReportQueryParams, GetResellerUserDashboardTransactionsCountQueryParams, GetResellerUserDashboardTransactionsReportQueryParams, GetResellerUserDashboardIntroducedCountQueryParams, GetResellerUserDashboardIntroducedReportQueryParams, GetTransactionQueryParams, GetTransactionExcelQueryParams, GetTransactionReportQueryParams, GetTransactionReportAllQueryParams, GetTransferSearchQueryParams, GetTransferRecentQueryParams, GetTransferUserWalletIdCommissionQueryParams, GetUserWalletAccountNumberQrcodeQueryParams, GetUserWalletUserWalletIdSettlementRequestComissionQueryParams, GetUserWalletUserWalletIdEpayRequestComissionQueryParams, GetUserWalletSearchQueryParams, GetUserWalletUserWalletIdTransferMoneyCommissionQueryParams, BankApiModel, BusinessCategoryApiModel, SubUserConnectionApiModel, EditConnectionInfoInput, SubUserPermissionApiModel, EditSubUserPermissionInput, SubUserActivityApiModel, EpayRequestApiModel, EpayRequestForUserQuery, EpayRequestDetailApiModel, ContactApiModel, CommissionAmountApiModel, UserMinimalDto, EpayRequestPublicInfoApiModel, WalletReceiptApiModel, AggregationApiModel, ReportApiModel, GroupTransferTargetValidationQuery, GroupTransferTargetValidationInput, DriverInfoResult, KpiResult, ImportantActionApiModel, NotificationApiModel, UnreadNotificationCountApiModel, PluginApiModel, PosLandingPageApiModel, BankReceiptApiModel, ResellerApiModel, ReselledUserFilterData, ReselledUserApiModel, ReselledUserActivityApiModel, DateReportApiModelOfDecimal, DateReportApiModelOfInteger, SubDomainApiModel, SubDomainUpdateApiModel, BusinessUserConnectionApiModel, SubUserAccountDetailQuery, TransactionApiModel, AllTransactionsReportApiModel, AccountInfoApiModel, TransferMoneyApiModel, UserBankApiModel, UserBankDetailApiModel, UserBankChangeVisibilityInput, UserDetailQuery, UserMeQuery, UserProfileInput, UserProfileAvatarInput, UserWorkspaceQuery, UserIdentityRequestQuery, UpgradeToBusinessApiModel, SubUserInvitationApiModel, UserPluginDetailApiModel, UserPluginApiModel, UserPluginTogggleApiModel, WalletDisplayApiModel, WalletDetailApiModel, AccountSettingNotificationStatusApiModel, AccountBalanceApiModel, AccountPermittedSubUserQuery, RequestBodyUserBankInput, RequestBodyAccountCreationApiModel,}  from \\"./types\\"
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const __DEV__ = process.env.NODE_ENV !== \\"production\\";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function overrideConfig(
+  config?: AxiosRequestConfig,
+  configOverride?: AxiosRequestConfig,
+): AxiosRequestConfig {
+  return {
+    ...config,
+    ...configOverride,
+    headers: {
+      ...config?.headers,
+      ...configOverride?.headers,
+    },
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function template(path: string, obj: { [x: string]: any } = {}) {
+    Object.keys(obj).forEach((key) => {
+      const re = new RegExp(\`{\${key}}\`, \\"i\\");
+      path = path.replace(re, obj[key]);
+    });
+
+    return path;
+}
+
+function isFormData(obj: any) {
+  // This checks for the append method which should exist on FormData instances
+  return (
+    (typeof obj === \\"object\\" &&
+      typeof obj.append === \\"function\\" &&
+      obj[Symbol.toStringTag] === undefined) ||
+    obj[Symbol.toStringTag] === \\"FormData\\"
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function objToForm(requestBody: object) {
+  if (isFormData(requestBody)) {
+    return requestBody;
+  }
+  const formData = new FormData();
+
+  Object.entries(requestBody).forEach(([key, value]) => {
+    value && formData.append(key, value);
+  });
+
+  return formData;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function objToUrlencoded(requestBody: object) {
+  return qs.stringify(requestBody)
+}
+
+
+/**
+ * 
+ * Disconnect sub user connection
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const deleteBusinessUserConnectionConnectionId = (
+    
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubUserConnectionApiModel)>> => {
+  
+  return Http.deleteRequest(
+    template(deleteBusinessUserConnectionConnectionId.key,{connectionId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+deleteBusinessUserConnectionConnectionId.key = \\"/BusinessUser/connection/{connectionId}\\";
+
+export const deleteBusinessUserConnectionConnectionIdPermissionUserWalletId = (
+    connectionId: number,
+/**
+ * 
+ * Id of Account to delete it's permissios
+ */
+userWalletId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.deleteRequest(
+    template(deleteBusinessUserConnectionConnectionIdPermissionUserWalletId.key,{connectionId,userWalletId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT5,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+deleteBusinessUserConnectionConnectionIdPermissionUserWalletId.key = \\"/BusinessUser/connection/{connectionId}/permission/{userWalletId}\\";
+
+
+/**
+ * 
+ * Remove an invitation
+[Feature just allowed for the business users]
+[Needs secure login]
+[Deprecated, use 'businessuser/invite/{invitationId}/remove' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const deleteBusinessUserConnectionInvitationIdRemove = (
+    invitationId: string,queryParams?: DeleteBusinessUserConnectionInvitationIdRemoveQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubUserConnectionApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"deleteBusinessUserConnectionInvitationIdRemove\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.deleteRequest(
+    template(deleteBusinessUserConnectionInvitationIdRemove.key,{invitationId,}),
+    queryParams,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+deleteBusinessUserConnectionInvitationIdRemove.key = \\"/BusinessUser/connection/{invitationId}/remove\\";
+
+
+/**
+ * 
+ * Remove an invitation
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const deleteBusinessUserInviteInvitationIdRemove = (
+    invitationId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubUserConnectionApiModel)>> => {
+  
+  return Http.deleteRequest(
+    template(deleteBusinessUserInviteInvitationIdRemove.key,{invitationId,}),
+    undefined,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+deleteBusinessUserInviteInvitationIdRemove.key = \\"/BusinessUser/invite/{invitationId}/remove\\";
+
+
+/**
+ * 
+ * Disconnect business user connection
+[Feature just allowed for SubUsers]
+[Needs secure login]
+[Deprecated, use 'user/connection/{connectionId}' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const deleteSubUserConnectionConnectionId = (
+    
+/**
+ * 
+ * connection id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (BusinessUserConnectionApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"deleteSubUserConnectionConnectionId\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.deleteRequest(
+    template(deleteSubUserConnectionConnectionId.key,{connectionId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+deleteSubUserConnectionConnectionId.key = \\"/SubUser/connection/{connectionId}\\";
+
+
+/**
+ * 
+ * Disconnect business user connection
+[Feature just allowed for normal users]
+[Needs secure login]
+ */
+export const deleteUserConnectionConnectionId = (
+    
+/**
+ * 
+ * connection id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (BusinessUserConnectionApiModel)>> => {
+  
+  return Http.deleteRequest(
+    template(deleteUserConnectionConnectionId.key,{connectionId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+deleteUserConnectionConnectionId.key = \\"/User/connection/{connectionId}\\";
+
+export const getAccessUserWalletIdLogicalAction = (
+    userWalletId: number,logicalAction: \\"EpayRequest\\" | \\"TransferMoney\\" | \\"AccountChargeRequest\\" | \\"ServiceBill\\" | \\"ServiceMobileCharge\\" | \\"POS\\" | \\"ShareAndBlockRequest\\" | \\"ShareRequest\\" | \\"Settlement\\" | \\"GroupTransferMoney\\" | \\"ShareAndUnblock\\" | \\"Refund\\" | \\"PayCommand\\" | \\"Gift\\" | \\"TaxiFairPayment\\" | \\"HitoBitFee\\",configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<boolean>> => {
+  
+  return Http.getRequest(
+    template(getAccessUserWalletIdLogicalAction.key,{userWalletId,logicalAction,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getAccessUserWalletIdLogicalAction.key = \\"/Access/{userWalletId}/{logicalAction}\\";
+
+
+/**
+ * 
+ * Get available banks
+ */
+export const getBank = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<BankApiModel[]>> => {
+  
+  return Http.getRequest(
+    getBank.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBank.key = \\"/Bank\\";
+
+
+/**
+ * 
+ * Get Business categories
+ */
+export const getBusinessUserCategory = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<BusinessCategoryApiModel[]>> => {
+  
+  return Http.getRequest(
+    getBusinessUserCategory.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBusinessUserCategory.key = \\"/BusinessUser/category\\";
+
+
+/**
+ * 
+ * Get the connections
+[Feature just allowed for the business users]
+ */
+export const getBusinessUserConnection = (
+    queryParams?: GetBusinessUserConnectionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<SubUserConnectionApiModel[]>> => {
+  
+  return Http.getRequest(
+    getBusinessUserConnection.key,
+    queryParams,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBusinessUserConnection.key = \\"/BusinessUser/connection\\";
+
+
+/**
+ * 
+ * Get active connections ordered by Transactions count
+[Feature just allowed for the business users]
+ */
+export const getBusinessUserConnectionActive = (
+    queryParams?: GetBusinessUserConnectionActiveQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<SubUserConnectionApiModel[]>> => {
+  
+  return Http.getRequest(
+    getBusinessUserConnectionActive.key,
+    queryParams,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBusinessUserConnectionActive.key = \\"/BusinessUser/connection/active\\";
+
+
+/**
+ * 
+ * Get the connection detail
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const getBusinessUserConnectionConnectionId = (
+    
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubUserConnectionApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getBusinessUserConnectionConnectionId.key,{connectionId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBusinessUserConnectionConnectionId.key = \\"/BusinessUser/connection/{connectionId}\\";
+
+
+/**
+ * 
+ * Get the connection amounts report
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const getBusinessUserConnectionConnectionIdActivity = (
+    
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubUserActivityApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getBusinessUserConnectionConnectionIdActivity.key,{connectionId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBusinessUserConnectionConnectionIdActivity.key = \\"/BusinessUser/connection/{connectionId}/activity\\";
+
+export const getBusinessUserConnectionConnectionIdEpay = (
+    connectionId: number,queryParams?: GetBusinessUserConnectionConnectionIdEpayQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<EpayRequestApiModel[]>> => {
+  
+  return Http.getRequest(
+    template(getBusinessUserConnectionConnectionIdEpay.key,{connectionId,}),
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBusinessUserConnectionConnectionIdEpay.key = \\"/BusinessUser/connection/{connectionId}/epay\\";
+
+
+/**
+ * 
+ * Get sub user permissions for accounts
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const getBusinessUserConnectionConnectionIdPermission = (
+    
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<SubUserPermissionApiModel[]>> => {
+  
+  return Http.getRequest(
+    template(getBusinessUserConnectionConnectionIdPermission.key,{connectionId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBusinessUserConnectionConnectionIdPermission.key = \\"/BusinessUser/connection/{connectionId}/permission\\";
+
+export const getEpayRequest = (
+    queryParams?: GetEpayRequestQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<EpayRequestApiModel[]>> => {
+  
+  return Http.getRequest(
+    getEpayRequest.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequest.key = \\"/EpayRequest\\";
+
+export const getEpayRequestAudiencesRecent = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<ContactApiModel[]>> => {
+  
+  return Http.getRequest(
+    getEpayRequestAudiencesRecent.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestAudiencesRecent.key = \\"/EpayRequest/audiences/recent\\";
+
+export const getEpayRequestCount = (
+    queryParams?: GetEpayRequestCountQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AggregationApiModel)>> => {
+  
+  return Http.getRequest(
+    getEpayRequestCount.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestCount.key = \\"/EpayRequest/count\\";
+
+
+/**
+ * 
+ * Get epay request detail based on Id
+ */
+export const getEpayRequestEpayId = (
+    
+/**
+ * 
+ * EpayRequest's Id
+ */
+epayId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (EpayRequestDetailApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getEpayRequestEpayId.key,{epayId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestEpayId.key = \\"/EpayRequest/{epayId}\\";
+
+export const getEpayRequestEpayTokenDetail = (
+    epayToken: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (EpayRequestPublicInfoApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getEpayRequestEpayTokenDetail.key,{epayToken,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestEpayTokenDetail.key = \\"/EpayRequest/{epayToken}/detail\\";
+
+
+/**
+ * 
+ * Get QR code image file for epay request
+ */
+export const getEpayRequestEpayTokenQrcode = (
+    
+/**
+ * 
+ * epay request token
+ */
+epayToken: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    template(getEpayRequestEpayTokenQrcode.key,{epayToken,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT5,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestEpayTokenQrcode.key = \\"/EpayRequest/{epayToken}/qrcode\\";
+
+export const getEpayRequestExcel = (
+    queryParams?: GetEpayRequestExcelQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    getEpayRequestExcel.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT5,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestExcel.key = \\"/EpayRequest/excel\\";
+
+
+/**
+ * 
+ * Get pay requests that the user is one of its audiences.
+[Feature is not allowed for sub users]
+[Needs secure login]
+ */
+export const getEpayRequestForMe = (
+    queryParams?: GetEpayRequestForMeQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<EpayRequestForUserQuery[]>> => {
+  
+  return Http.getRequest(
+    getEpayRequestForMe.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestForMe.key = \\"/EpayRequest/forMe\\";
+
+export const getEpayRequestForMeCount = (
+    queryParams?: GetEpayRequestForMeCountQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AggregationApiModel)>> => {
+  
+  return Http.getRequest(
+    getEpayRequestForMeCount.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestForMeCount.key = \\"/EpayRequest/forMe/count\\";
+
+export const getEpayRequestForMeReport = (
+    queryParams?: GetEpayRequestForMeReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<ReportApiModel[]>> => {
+  
+  return Http.getRequest(
+    getEpayRequestForMeReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestForMeReport.key = \\"/EpayRequest/forMe/report\\";
+
+
+/**
+ * 
+ * [Deprecated, use 'account/{accountNumber}/qrcode' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getEpayRequestPosQrAccountNumber = (
+    accountNumber: string,queryParams?: GetEpayRequestPosQrAccountNumberQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getEpayRequestPosQrAccountNumber\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    template(getEpayRequestPosQrAccountNumber.key,{accountNumber,}),
+    queryParams,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT5,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestPosQrAccountNumber.key = \\"/EpayRequest/pos/Qr/{accountNumber}\\";
+
+export const getEpayRequestReport = (
+    queryParams?: GetEpayRequestReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<ReportApiModel[]>> => {
+  
+  return Http.getRequest(
+    getEpayRequestReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestReport.key = \\"/EpayRequest/report\\";
+
+
+/**
+ * 
+ * Get comission amount for epay request amount
+ */
+export const getEpayRequestUserWalletIdCommission = (
+    userWalletId: number,queryParams?: GetEpayRequestUserWalletIdCommissionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (CommissionAmountApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getEpayRequestUserWalletIdCommission.key,{userWalletId,}),
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestUserWalletIdCommission.key = \\"/EpayRequest/{userWalletId}/commission\\";
+
+export const getEpayRequestUserWalletIdCreators = (
+    userWalletId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<UserMinimalDto[]>> => {
+  
+  return Http.getRequest(
+    template(getEpayRequestUserWalletIdCreators.key,{userWalletId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestUserWalletIdCreators.key = \\"/EpayRequest/{userWalletId}/creators\\";
+
+export const getError = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    getError.key,
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT5,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getError.key = \\"/error\\";
+
+export const getErrorLocal = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    getErrorLocal.key,
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT5,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getErrorLocal.key = \\"/error/local\\";
+
+export const getErrorStatusCode = (
+    code: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    template(getErrorStatusCode.key,{code,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT5,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getErrorStatusCode.key = \\"/error/status/{code}\\";
+
+
+/**
+ * 
+ * Download a file.
+ */
+export const getFileFileGuid = (
+    
+/**
+ * 
+ * file unique id
+ */
+fileGuid: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    template(getFileFileGuid.key,{fileGuid,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT5,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getFileFileGuid.key = \\"/File/{fileGuid}\\";
+
+export const getGroupTransferCommission = (
+    queryParams?: GetGroupTransferCommissionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (CommissionAmountApiModel)>> => {
+  
+  return Http.getRequest(
+    getGroupTransferCommission.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getGroupTransferCommission.key = \\"/GroupTransfer/commission\\";
+
+
+/**
+ * 
+ * Get detailed driver,taxi and fair amount information
+ */
+export const getIntegration = (
+    queryParams?: GetIntegrationQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (DriverInfoResult)>> => {
+  
+  return Http.getRequest(
+    getIntegration.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT6,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getIntegration.key = \\"/Integration\\";
+
+export const getKpi = (
+    queryParams?: GetKpiQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<KpiResult[]>> => {
+  
+  return Http.getRequest(
+    getKpi.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getKpi.key = \\"/Kpi\\";
+
+export const getKpiCurrent = (
+    queryParams?: GetKpiCurrentQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<KpiResult[]>> => {
+  
+  return Http.getRequest(
+    getKpiCurrent.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getKpiCurrent.key = \\"/Kpi/Current\\";
+
+export const getKpiLast = (
+    queryParams?: GetKpiLastQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<KpiResult[]>> => {
+  
+  return Http.getRequest(
+    getKpiLast.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getKpiLast.key = \\"/Kpi/Last\\";
+
+
+/**
+ * 
+ * Get all Important Actions of current user.
+ */
+export const getNotificationIa = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<ImportantActionApiModel[]>> => {
+  
+  return Http.getRequest(
+    getNotificationIa.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getNotificationIa.key = \\"/Notification/ia\\";
+
+
+/**
+ * 
+ * Get Notifications of current user.
+Maximum 99 items will be returned.
+ */
+export const getNotificationNotif = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<NotificationApiModel[]>> => {
+  
+  return Http.getRequest(
+    getNotificationNotif.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getNotificationNotif.key = \\"/Notification/notif\\";
+
+export const getNotificationUnread = (
+    queryParams?: GetNotificationUnreadQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<UnreadNotificationCountApiModel[]>> => {
+  
+  return Http.getRequest(
+    getNotificationUnread.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getNotificationUnread.key = \\"/Notification/unread\\";
+
+export const getPluginPluginId = (
+    pluginId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (PluginApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getPluginPluginId.key,{pluginId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getPluginPluginId.key = \\"/Plugin/{pluginId}\\";
+
+
+/**
+ * 
+ * Get epay request detail
+ */
+export const getPosAccountNumber = (
+    
+/**
+ * 
+ * Account Number
+ */
+accountNumber: string,queryParams?: GetPosAccountNumberQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (PosLandingPageApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getPosAccountNumber.key,{accountNumber,}),
+    queryParams,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getPosAccountNumber.key = \\"/Pos/{accountNumber}\\";
+
+
+/**
+ * 
+ * Get bank receipt by EPayTry id
+[For anonymous users]
+ */
+export const getReceiptBankEpayTryId = (
+    
+/**
+ * 
+ * EpayTry's id to get receipt for
+ */
+epayTryId: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (BankReceiptApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getReceiptBankEpayTryId.key,{epayTryId,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getReceiptBankEpayTryId.key = \\"/Receipt/bank/{epayTryId}\\";
+
+
+/**
+ * 
+ * Get bank receipt by EPayRequest token
+[For anonymous users]
+[Deprecated, use 'receipt/bank/{epayTryId}' and 'receipt/bank/{epayTryId}' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getReceiptEpayToken = (
+    
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (BankReceiptApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getReceiptEpayToken\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    template(getReceiptEpayToken.key,{epayToken,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getReceiptEpayToken.key = \\"/Receipt/{epayToken}\\";
+
+
+/**
+ * 
+ * Get wallet receipt by EPayRequest token
+[For anonymous users]
+ */
+export const getReceiptWalletEpayToken = (
+    
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (WalletReceiptApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getReceiptWalletEpayToken.key,{epayToken,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getReceiptWalletEpayToken.key = \\"/Receipt/wallet/{epayToken}\\";
+
+
+/**
+ * 
+ * Get the Resellership info of current Reseller user
+[Feature just allowed for Resellers]
+ */
+export const getResellerUser = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (ResellerApiModel)>> => {
+  
+  return Http.getRequest(
+    getResellerUser.key,
+    undefined,
+    undefined,
+    _CONSTANT7,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUser.key = \\"/ResellerUser\\";
+
+
+/**
+ * 
+ * Get the time-based report of commissions paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardCommissionReport = (
+    queryParams?: GetResellerUserDashboardCommissionReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<DateReportApiModelOfDecimal[]>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardCommissionReport\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardCommissionReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT7,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardCommissionReport.key = \\"/ResellerUser/dashboard/commission/report\\";
+
+
+/**
+ * 
+ * Get sum of all commissions paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardCommissionSum = (
+    queryParams?: GetResellerUserDashboardCommissionSumQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AggregationApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardCommissionSum\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardCommissionSum.key,
+    queryParams,
+    undefined,
+    _CONSTANT7,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardCommissionSum.key = \\"/ResellerUser/dashboard/commission/sum\\";
+
+
+/**
+ * 
+ * Get count of all users reselled by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardIntroducedCount = (
+    queryParams?: GetResellerUserDashboardIntroducedCountQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AggregationApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardIntroducedCount\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardIntroducedCount.key,
+    queryParams,
+    undefined,
+    _CONSTANT7,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardIntroducedCount.key = \\"/ResellerUser/dashboard/introduced/count\\";
+
+
+/**
+ * 
+ * Get time-based report of users reselled by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardIntroducedReport = (
+    queryParams?: GetResellerUserDashboardIntroducedReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<DateReportApiModelOfInteger[]>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardIntroducedReport\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardIntroducedReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT7,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardIntroducedReport.key = \\"/ResellerUser/dashboard/introduced/report\\";
+
+
+/**
+ * 
+ * Get count of all links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardLinksCount = (
+    queryParams?: GetResellerUserDashboardLinksCountQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AggregationApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardLinksCount\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardLinksCount.key,
+    queryParams,
+    undefined,
+    _CONSTANT7,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardLinksCount.key = \\"/ResellerUser/dashboard/links/count\\";
+
+
+/**
+ * 
+ * Get count of all paid links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardLinksPaidCount = (
+    queryParams?: GetResellerUserDashboardLinksPaidCountQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AggregationApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardLinksPaidCount\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardLinksPaidCount.key,
+    queryParams,
+    undefined,
+    _CONSTANT7,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardLinksPaidCount.key = \\"/ResellerUser/dashboard/links/paid/count\\";
+
+
+/**
+ * 
+ * Get time-based report of paid links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardLinksPaidReport = (
+    queryParams?: GetResellerUserDashboardLinksPaidReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<DateReportApiModelOfInteger[]>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardLinksPaidReport\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardLinksPaidReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT7,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardLinksPaidReport.key = \\"/ResellerUser/dashboard/links/paid/report\\";
+
+
+/**
+ * 
+ * Get time-based report of links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardLinksReport = (
+    queryParams?: GetResellerUserDashboardLinksReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<DateReportApiModelOfInteger[]>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardLinksReport\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardLinksReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT7,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardLinksReport.key = \\"/ResellerUser/dashboard/links/report\\";
+
+
+/**
+ * 
+ * Get count of all commission transactions, paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardTransactionsCount = (
+    queryParams?: GetResellerUserDashboardTransactionsCountQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AggregationApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardTransactionsCount\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardTransactionsCount.key,
+    queryParams,
+    undefined,
+    _CONSTANT7,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardTransactionsCount.key = \\"/ResellerUser/dashboard/transactions/count\\";
+
+
+/**
+ * 
+ * Get time-based report of commission transactions, paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardTransactionsReport = (
+    queryParams?: GetResellerUserDashboardTransactionsReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<DateReportApiModelOfInteger[]>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardTransactionsReport\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardTransactionsReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT7,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardTransactionsReport.key = \\"/ResellerUser/dashboard/transactions/report\\";
+
+
+/**
+ * 
+ * Get the Users Introduced by current Reseller user
+[Feature just allowed for Resellers]
+ */
+export const getResellerUserIntroduced = (
+    queryParams?: GetResellerUserIntroducedQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<ReselledUserApiModel[]>> => {
+  
+  return Http.getRequest(
+    getResellerUserIntroduced.key,
+    queryParams,
+    undefined,
+    _CONSTANT7,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserIntroduced.key = \\"/ResellerUser/introduced\\";
+
+
+/**
+ * 
+ * Get filter data items to populate DropDowns
+[Feature just allowed for Resellers]
+ */
+export const getResellerUserIntroducedFilterData = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (ReselledUserFilterData)>> => {
+  
+  return Http.getRequest(
+    getResellerUserIntroducedFilterData.key,
+    undefined,
+    undefined,
+    _CONSTANT7,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserIntroducedFilterData.key = \\"/ResellerUser/introduced/filterData\\";
+
+
+/**
+ * 
+ * Get the User activity
+[Feature just allowed for Resellers]
+ */
+export const getResellerUserIntroducedUserIdActivity = (
+    userId: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (ReselledUserActivityApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getResellerUserIntroducedUserIdActivity.key,{userId,}),
+    undefined,
+    undefined,
+    _CONSTANT7,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserIntroducedUserIdActivity.key = \\"/ResellerUser/introduced/{userId}/activity\\";
+
+
+/**
+ * 
+ * Get the SubDomain of current Reseller user
+[Feature just allowed for Resellers]
+ */
+export const getSubDomain = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubDomainApiModel)>> => {
+  
+  return Http.getRequest(
+    getSubDomain.key,
+    undefined,
+    undefined,
+    _CONSTANT7,
+    overrideConfig(_CONSTANT6,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getSubDomain.key = \\"/SubDomain\\";
+
+
+/**
+ * 
+ * Get info of a SubDomain by it's address.
+ */
+export const getSubDomainSubDomainAddress = (
+    
+/**
+ * 
+ * The SubDomain part of the url.
+            
+ */
+subDomainAddress: string,headerParams?: {
+/**
+ * 
+ * - Format: guid
+ */
+\\"clientId\\": string;},configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubDomainApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getSubDomainSubDomainAddress.key,{subDomainAddress,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig({
+              headers:{
+                ..._CONSTANT8,
+                ...headerParams,
+              },
+            },
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getSubDomainSubDomainAddress.key = \\"/SubDomain/{subDomainAddress}\\";
+
+
+/**
+ * 
+ * Get permission details of an Account
+[Feature just allowed for SubUsers]
+ */
+export const getSubUserAccountUserWalletId = (
+    userWalletId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubUserAccountDetailQuery)>> => {
+  
+  return Http.getRequest(
+    template(getSubUserAccountUserWalletId.key,{userWalletId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getSubUserAccountUserWalletId.key = \\"/SubUser/account/{userWalletId}\\";
+
+
+/**
+ * 
+ * Get the connections
+[Feature just allowed for SubUsers]
+[Deprecated. use 'user/connection' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getSubUserConnection = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<BusinessUserConnectionApiModel[]>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getSubUserConnection\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getSubUserConnection.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getSubUserConnection.key = \\"/SubUser/connection\\";
+
+export const getTransaction = (
+    queryParams?: GetTransactionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<TransactionApiModel[]>> => {
+  
+  return Http.getRequest(
+    getTransaction.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransaction.key = \\"/Transaction\\";
+
+export const getTransactionExcel = (
+    queryParams?: GetTransactionExcelQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    getTransactionExcel.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT5,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransactionExcel.key = \\"/Transaction/excel\\";
+
+
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getTransactionReport = (
+    queryParams?: GetTransactionReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<ReportApiModel[]>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getTransactionReport\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getTransactionReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransactionReport.key = \\"/Transaction/report\\";
+
+
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getTransactionReportAll = (
+    queryParams?: GetTransactionReportAllQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AllTransactionsReportApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getTransactionReportAll\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getTransactionReportAll.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransactionReportAll.key = \\"/Transaction/report/all\\";
+
+
+/**
+ * 
+ * Get a Transaction by it's Id
+[Needs secure login]
+ */
+export const getTransactionTransactionId = (
+    transactionId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (TransactionApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getTransactionTransactionId.key,{transactionId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransactionTransactionId.key = \\"/Transaction/{transactionId}\\";
+
+
+/**
+ * 
+ * Get recent money transfers
+ */
+export const getTransferRecent = (
+    queryParams?: GetTransferRecentQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<TransferMoneyApiModel[]>> => {
+  
+  return Http.getRequest(
+    getTransferRecent.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransferRecent.key = \\"/Transfer/recent\\";
+
+export const getTransferSearch = (
+    queryParams?: GetTransferSearchQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AccountInfoApiModel)>> => {
+  
+  return Http.getRequest(
+    getTransferSearch.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransferSearch.key = \\"/Transfer/search\\";
+
+
+/**
+ * 
+ * Get commission amount for transfer money amount
+ */
+export const getTransferUserWalletIdCommission = (
+    userWalletId: number,queryParams?: GetTransferUserWalletIdCommissionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (CommissionAmountApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getTransferUserWalletIdCommission.key,{userWalletId,}),
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransferUserWalletIdCommission.key = \\"/Transfer/{userWalletId}/commission\\";
+
+
+/**
+ * 
+ * Get [normal/sub/business] user profile detail
+ */
+export const getUser = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (UserDetailQuery)>> => {
+  
+  return Http.getRequest(
+    getUser.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUser.key = \\"/User\\";
+
+
+/**
+ * 
+ * Get user banks
+[Feature is not allowed for sub users.]
+ */
+export const getUserBank = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<UserBankApiModel[]>> => {
+  
+  return Http.getRequest(
+    getUserBank.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserBank.key = \\"/UserBank\\";
+
+
+/**
+ * 
+ * Get available user banks
+[Feature is not allowed for sub users.]
+ */
+export const getUserBankReady = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<UserBankApiModel[]>> => {
+  
+  return Http.getRequest(
+    getUserBankReady.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserBankReady.key = \\"/UserBank/ready\\";
+
+
+/**
+ * 
+ * get user bank detail
+[Needs secure login]
+ */
+export const getUserBankUserBankId = (
+    
+/**
+ * 
+ * User bank id
+ */
+userBankId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (UserBankDetailApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getUserBankUserBankId.key,{userBankId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserBankUserBankId.key = \\"/UserBank/{userBankId}\\";
+
+
+/**
+ * 
+ * Get the connections [Feature is allowed for normal users noly]
+ */
+export const getUserConnection = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<BusinessUserConnectionApiModel[]>> => {
+  
+  return Http.getRequest(
+    getUserConnection.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserConnection.key = \\"/User/connection\\";
+
+export const getUserContactInput = (
+    input: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (ContactApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getUserContactInput.key,{input,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserContactInput.key = \\"/User/contact/{input}\\";
+
+
+/**
+ * 
+ * Get last national id verification request [Feature is not allowed for sub users]
+ */
+export const getUserIdentityRequest = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (UserIdentityRequestQuery)>> => {
+  
+  return Http.getRequest(
+    getUserIdentityRequest.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserIdentityRequest.key = \\"/User/identityRequest\\";
+
+
+/**
+ * 
+ * Get business user invitations for me [Feature is not allowed for sub users]
+ */
+export const getUserInvitation = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<SubUserInvitationApiModel[]>> => {
+  
+  return Http.getRequest(
+    getUserInvitation.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserInvitation.key = \\"/User/invitation\\";
+
+
+/**
+ * 
+ * Get business user invitations for me [Feature is not allowed for sub users]
+ */
+export const getUserInvitationInvitationToken = (
+    invitationToken: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubUserInvitationApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getUserInvitationInvitationToken.key,{invitationToken,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserInvitationInvitationToken.key = \\"/User/invitation/{invitationToken}\\";
+
+
+/**
+ * 
+ * Get user profile summary
+ */
+export const getUserMe = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (UserMeQuery)>> => {
+  
+  return Http.getRequest(
+    getUserMe.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserMe.key = \\"/User/me\\";
+
+export const getUserPlugin = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<UserPluginDetailApiModel[]>> => {
+  
+  return Http.getRequest(
+    getUserPlugin.key,
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserPlugin.key = \\"/UserPlugin\\";
+
+
+/**
+ * 
+ * Get Last Request for upgrade account to the business [Feature is allowed for normal users only]
+ */
+export const getUserUpgradeToBusinessRequest = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (UpgradeToBusinessApiModel)>> => {
+  
+  return Http.getRequest(
+    getUserUpgradeToBusinessRequest.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserUpgradeToBusinessRequest.key = \\"/User/upgradeToBusinessRequest\\";
+
+export const getUserWallet = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<WalletDisplayApiModel[]>> => {
+  
+  return Http.getRequest(
+    getUserWallet.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWallet.key = \\"/UserWallet\\";
+
+export const getUserWalletAccountNumberQrcode = (
+    accountNumber: string,queryParams?: GetUserWalletAccountNumberQrcodeQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    template(getUserWalletAccountNumberQrcode.key,{accountNumber,}),
+    queryParams,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT5,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletAccountNumberQrcode.key = \\"/UserWallet/{accountNumber}/qrcode\\";
+
+
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getUserWalletSearch = (
+    queryParams?: GetUserWalletSearchQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AccountInfoApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getUserWalletSearch\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getUserWalletSearch.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletSearch.key = \\"/UserWallet/search\\";
+
+export const getUserWalletUserWalletId = (
+    userWalletId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (WalletDetailApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getUserWalletUserWalletId.key,{userWalletId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletUserWalletId.key = \\"/UserWallet/{userWalletId}\\";
+
+
+/**
+ * 
+ * Get user account balance
+ */
+export const getUserWalletUserWalletIdBalance = (
+    userWalletId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AccountBalanceApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getUserWalletUserWalletIdBalance.key,{userWalletId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletUserWalletIdBalance.key = \\"/UserWallet/{userWalletId}/balance\\";
+
+
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getUserWalletUserWalletIdEpayRequestComission = (
+    userWalletId: number,queryParams?: GetUserWalletUserWalletIdEpayRequestComissionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (CommissionAmountApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getUserWalletUserWalletIdEpayRequestComission\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    template(getUserWalletUserWalletIdEpayRequestComission.key,{userWalletId,}),
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletUserWalletIdEpayRequestComission.key = \\"/UserWallet/{userWalletId}/epayRequest/comission\\";
+
+export const getUserWalletUserWalletIdPermittedsubusers = (
+    userWalletId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<AccountPermittedSubUserQuery[]>> => {
+  
+  return Http.getRequest(
+    template(getUserWalletUserWalletIdPermittedsubusers.key,{userWalletId,}),
+    undefined,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletUserWalletIdPermittedsubusers.key = \\"/UserWallet/{userWalletId}/permittedsubusers\\";
+
+export const getUserWalletUserWalletIdSettlementRequestComission = (
+    userWalletId: number,queryParams?: GetUserWalletUserWalletIdSettlementRequestComissionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (CommissionAmountApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getUserWalletUserWalletIdSettlementRequestComission.key,{userWalletId,}),
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletUserWalletIdSettlementRequestComission.key = \\"/UserWallet/{userWalletId}/settlementRequest/comission\\";
+
+
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getUserWalletUserWalletIdTransferMoneyCommission = (
+    userWalletId: number,queryParams?: GetUserWalletUserWalletIdTransferMoneyCommissionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (CommissionAmountApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getUserWalletUserWalletIdTransferMoneyCommission\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    template(getUserWalletUserWalletIdTransferMoneyCommission.key,{userWalletId,}),
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletUserWalletIdTransferMoneyCommission.key = \\"/UserWallet/{userWalletId}/transferMoney/commission\\";
+
+
+/**
+ * 
+ * Get user work spaces
+ */
+export const getUserWorkspace = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<UserWorkspaceQuery[]>> => {
+  
+  return Http.getRequest(
+    getUserWorkspace.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWorkspace.key = \\"/User/workspace\\";
+
+
+/**
+ * 
+ * Change sub user connection info
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const putBusinessUserConnectionConnectionId = (
+    
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,requestBody: EditConnectionInfoInput,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubUserConnectionApiModel)>> => {
+  
+  return Http.putRequest(
+    template(putBusinessUserConnectionConnectionId.key,{connectionId,}),
+    undefined,
+    requestBody,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+putBusinessUserConnectionConnectionId.key = \\"/BusinessUser/connection/{connectionId}\\";
+
+export const putBusinessUserConnectionConnectionIdPermissionUserWalletId = (
+    connectionId: number,
+/**
+ * 
+ * Id of Account to edit it's permissios
+ */
+userWalletId: number,requestBody: EditSubUserPermissionInput,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.putRequest(
+    template(putBusinessUserConnectionConnectionIdPermissionUserWalletId.key,{connectionId,userWalletId,}),
+    undefined,
+    requestBody,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT4,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+putBusinessUserConnectionConnectionIdPermissionUserWalletId.key = \\"/BusinessUser/connection/{connectionId}/permission/{userWalletId}\\";
+
+
+/**
+ * 
+ * [for Business users only]
+ */
+export const putGroupTransferAdd = (
+    requestBody: GroupTransferTargetValidationInput,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (GroupTransferTargetValidationQuery)>> => {
+  
+  return Http.putRequest(
+    putGroupTransferAdd.key,
+    undefined,
+    requestBody,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+putGroupTransferAdd.key = \\"/GroupTransfer/add\\";
+
+
+/**
+ * 
+ * Dismiss an Important Action forever.
+ */
+export const putNotificationIaNotifIdDismiss = (
+    notifId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.putRequest(
+    template(putNotificationIaNotifIdDismiss.key,{notifId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT5,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+putNotificationIaNotifIdDismiss.key = \\"/Notification/ia/{notifId}/dismiss\\";
+
+
+/**
+ * 
+ * Update the SubDomain of current Reseller user
+[Feature just allowed for Resellers]
+ */
+export const putSubDomain = (
+    requestBody: SubDomainUpdateApiModel,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubDomainApiModel)>> => {
+  
+  return Http.putRequest(
+    putSubDomain.key,
+    undefined,
+    requestBody,
+    _CONSTANT7,
+    overrideConfig(_CONSTANT9,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+putSubDomain.key = \\"/SubDomain\\";
+
+
+/**
+ * 
+ * Edit profile [state, city, address]
+[Feature is not allowed for business users]
+[Needs secure login]
+ */
+export const putUser = (
+    requestBody: UserProfileInput,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (UserDetailQuery)>> => {
+  
+  return Http.putRequest(
+    putUser.key,
+    undefined,
+    requestBody,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+putUser.key = \\"/User\\";
+
+
+/**
+ * 
+ * Edit user bank
+[Needs secure login]
+ */
+export const putUserBankUserBankId = (
+    
+/**
+ * 
+ * User bank id
+ */
+userBankId: number,requestBody: RequestBodyUserBankInput,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (UserBankApiModel)>> => {
+  
+  return Http.putRequest(
+    template(putUserBankUserBankId.key,{userBankId,}),
+    undefined,
+    requestBody,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+putUserBankUserBankId.key = \\"/UserBank/{userBankId}\\";
+
+
+/**
+ * 
+ * Change user bank show-in-list property
+[Needs secure login]
+ */
+export const putUserBankUserBankIdChangeVisibility = (
+    userBankId: number,requestBody: UserBankChangeVisibilityInput,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.putRequest(
+    template(putUserBankUserBankIdChangeVisibility.key,{userBankId,}),
+    undefined,
+    requestBody,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT4,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+putUserBankUserBankIdChangeVisibility.key = \\"/UserBank/{userBankId}/changeVisibility\\";
+
+
+/**
+ * 
+ * Change user avatar
+[Needs secure login]
+ */
+export const putUserChangeAvatar = (
+    requestBody: UserProfileAvatarInput,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.putRequest(
+    putUserChangeAvatar.key,
+    undefined,
+    requestBody,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT4,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+putUserChangeAvatar.key = \\"/User/changeAvatar\\";
+
+export const putUserPluginUserPluginIdChangeStatus = (
+    userPluginId: number,requestBody: UserPluginTogggleApiModel,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (UserPluginApiModel)>> => {
+  
+  return Http.putRequest(
+    template(putUserPluginUserPluginIdChangeStatus.key,{userPluginId,}),
+    undefined,
+    requestBody,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+putUserPluginUserPluginIdChangeStatus.key = \\"/UserPlugin/{userPluginId}/ChangeStatus\\";
+
+export const putUserWalletUserWalletId = (
+    userWalletId: number,requestBody: RequestBodyAccountCreationApiModel,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (WalletDisplayApiModel)>> => {
+  
+  return Http.putRequest(
+    template(putUserWalletUserWalletId.key,{userWalletId,}),
+    undefined,
+    requestBody,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+putUserWalletUserWalletId.key = \\"/UserWallet/{userWalletId}\\";
+
+export const putUserWalletUserWalletIdNotification = (
+    userWalletId: number,requestBody: AccountSettingNotificationStatusApiModel,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.putRequest(
+    template(putUserWalletUserWalletIdNotification.key,{userWalletId,}),
+    undefined,
+    requestBody,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT4,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+putUserWalletUserWalletIdNotification.key = \\"/UserWallet/{userWalletId}/notification\\";
+export const _CONSTANT0 = {
+              headers: {
+                \\"Content-Type\\": \\"application/json\\",
+                Accept: \\"application/json\\",
+              },
+            };export const _CONSTANT1 = [{\\"bearer\\":[]}];export const _CONSTANT2 = [{\\"bearer\\":[\\"Business\\"]}];export const _CONSTANT3 = {
+              headers: {
+                \\"Content-Type\\": \\"application/json-patch+json\\",
+                Accept: \\"application/json\\",
+              },
+            };export const _CONSTANT4 = {
+              headers: {
+                \\"Content-Type\\": \\"application/json-patch+json\\",
+                Accept: \\"*/*\\",
+              },
+            };export const _CONSTANT5 = {
+              headers: {
+                \\"Content-Type\\": \\"application/json\\",
+                Accept: \\"*/*\\",
+              },
+            };export const _CONSTANT6 = {
+              headers: {
+                \\"Content-Type\\": \\"application/json\\",
+                Accept: \\"text/plain\\",
+              },
+            };export const _CONSTANT7 = [{\\"bearer\\":[\\"Reseller\\"]}];export const _CONSTANT8 = {
+                  \\"Content-Type\\": \\"application/json\\",
+                  Accept: \\"text/plain\\",
+
+                };export const _CONSTANT9 = {
+              headers: {
+                \\"Content-Type\\": \\"application/json-patch+json\\",
+                Accept: \\"text/plain\\",
+              },
+            };"
+`;
+
+exports[`excludes post methods generate hooks 1`] = `
+"
+//@ts-nocheck
+/**
+* AUTO_GENERATED Do not change this file directly, use config.ts file instead
+*
+* @version 6
+*/
+
+
+import { AxiosRequestConfig } from \\"axios\\";
+import {
+  UseQueryOptions,
+  useQuery,
+  useMutation,
+  UseMutationOptions,
+  
+  QueryClient,
+  QueryKey,
+} from \\"@tanstack/react-query\\";
+import { RequestError, SwaggerResponse } from \\"./config\\";
+
+import type { AccountBalanceApiModel, AccountInfoApiModel, AccountPermittedSubUserQuery, AccountSettingNotificationStatusApiModel, AggregationApiModel, AllTransactionsReportApiModel, BankApiModel, BankReceiptApiModel, BusinessCategoryApiModel, BusinessUserConnectionApiModel, CommissionAmountApiModel, ContactApiModel, DateReportApiModelOfDecimal, DateReportApiModelOfInteger, DeleteBusinessUserConnectionInvitationIdRemoveQueryParams, DriverInfoResult, EditConnectionInfoInput, EditSubUserPermissionInput, EpayRequestApiModel, EpayRequestDetailApiModel, EpayRequestForUserQuery, EpayRequestPublicInfoApiModel, GetBusinessUserConnectionActiveQueryParams, GetBusinessUserConnectionConnectionIdEpayQueryParams, GetBusinessUserConnectionQueryParams, GetEpayRequestCountQueryParams, GetEpayRequestExcelQueryParams, GetEpayRequestForMeCountQueryParams, GetEpayRequestForMeQueryParams, GetEpayRequestForMeReportQueryParams, GetEpayRequestPosQrAccountNumberQueryParams, GetEpayRequestQueryParams, GetEpayRequestReportQueryParams, GetEpayRequestUserWalletIdCommissionQueryParams, GetGroupTransferCommissionQueryParams, GetIntegrationQueryParams, GetKpiCurrentQueryParams, GetKpiLastQueryParams, GetKpiQueryParams, GetNotificationUnreadQueryParams, GetPosAccountNumberQueryParams, GetResellerUserDashboardCommissionReportQueryParams, GetResellerUserDashboardCommissionSumQueryParams, GetResellerUserDashboardIntroducedCountQueryParams, GetResellerUserDashboardIntroducedReportQueryParams, GetResellerUserDashboardLinksCountQueryParams, GetResellerUserDashboardLinksPaidCountQueryParams, GetResellerUserDashboardLinksPaidReportQueryParams, GetResellerUserDashboardLinksReportQueryParams, GetResellerUserDashboardTransactionsCountQueryParams, GetResellerUserDashboardTransactionsReportQueryParams, GetResellerUserIntroducedQueryParams, GetTransactionExcelQueryParams, GetTransactionQueryParams, GetTransactionReportAllQueryParams, GetTransactionReportQueryParams, GetTransferRecentQueryParams, GetTransferSearchQueryParams, GetTransferUserWalletIdCommissionQueryParams, GetUserWalletAccountNumberQrcodeQueryParams, GetUserWalletSearchQueryParams, GetUserWalletUserWalletIdEpayRequestComissionQueryParams, GetUserWalletUserWalletIdSettlementRequestComissionQueryParams, GetUserWalletUserWalletIdTransferMoneyCommissionQueryParams, GroupTransferTargetValidationInput, GroupTransferTargetValidationQuery, ImportantActionApiModel, KpiResult, NotificationApiModel, PluginApiModel, PosLandingPageApiModel, ReportApiModel, RequestBodyAccountCreationApiModel, RequestBodyUserBankInput, ReselledUserActivityApiModel, ReselledUserApiModel, ReselledUserFilterData, ResellerApiModel, SubDomainApiModel, SubDomainUpdateApiModel, SubUserAccountDetailQuery, SubUserActivityApiModel, SubUserConnectionApiModel, SubUserInvitationApiModel, SubUserPermissionApiModel, TransactionApiModel, TransferMoneyApiModel, UnreadNotificationCountApiModel, UpgradeToBusinessApiModel, UserBankApiModel, UserBankChangeVisibilityInput, UserBankDetailApiModel, UserDetailQuery, UserIdentityRequestQuery, UserMeQuery, UserMinimalDto, UserPluginApiModel, UserPluginDetailApiModel, UserPluginTogggleApiModel, UserProfileAvatarInput, UserProfileInput, UserWorkspaceQuery, WalletDetailApiModel, WalletDisplayApiModel, WalletReceiptApiModel,}  from \\"./types\\"
+import { deleteBusinessUserConnectionConnectionId, deleteBusinessUserConnectionConnectionIdPermissionUserWalletId, deleteBusinessUserConnectionInvitationIdRemove, deleteBusinessUserInviteInvitationIdRemove, deleteSubUserConnectionConnectionId, deleteUserConnectionConnectionId, getAccessUserWalletIdLogicalAction, getBank, getBusinessUserCategory, getBusinessUserConnection, getBusinessUserConnectionActive, getBusinessUserConnectionConnectionId, getBusinessUserConnectionConnectionIdActivity, getBusinessUserConnectionConnectionIdEpay, getBusinessUserConnectionConnectionIdPermission, getEpayRequest, getEpayRequestAudiencesRecent, getEpayRequestCount, getEpayRequestEpayId, getEpayRequestEpayTokenDetail, getEpayRequestEpayTokenQrcode, getEpayRequestExcel, getEpayRequestForMe, getEpayRequestForMeCount, getEpayRequestForMeReport, getEpayRequestPosQrAccountNumber, getEpayRequestReport, getEpayRequestUserWalletIdCommission, getEpayRequestUserWalletIdCreators, getError, getErrorLocal, getErrorStatusCode, getFileFileGuid, getGroupTransferCommission, getIntegration, getKpi, getKpiCurrent, getKpiLast, getNotificationIa, getNotificationNotif, getNotificationUnread, getPluginPluginId, getPosAccountNumber, getReceiptBankEpayTryId, getReceiptEpayToken, getReceiptWalletEpayToken, getResellerUser, getResellerUserDashboardCommissionReport, getResellerUserDashboardCommissionSum, getResellerUserDashboardIntroducedCount, getResellerUserDashboardIntroducedReport, getResellerUserDashboardLinksCount, getResellerUserDashboardLinksPaidCount, getResellerUserDashboardLinksPaidReport, getResellerUserDashboardLinksReport, getResellerUserDashboardTransactionsCount, getResellerUserDashboardTransactionsReport, getResellerUserIntroduced, getResellerUserIntroducedFilterData, getResellerUserIntroducedUserIdActivity, getSubDomain, getSubDomainSubDomainAddress, getSubUserAccountUserWalletId, getSubUserConnection, getTransaction, getTransactionExcel, getTransactionReport, getTransactionReportAll, getTransactionTransactionId, getTransferRecent, getTransferSearch, getTransferUserWalletIdCommission, getUser, getUserBank, getUserBankReady, getUserBankUserBankId, getUserConnection, getUserContactInput, getUserIdentityRequest, getUserInvitation, getUserInvitationInvitationToken, getUserMe, getUserPlugin, getUserUpgradeToBusinessRequest, getUserWallet, getUserWalletAccountNumberQrcode, getUserWalletSearch, getUserWalletUserWalletId, getUserWalletUserWalletIdBalance, getUserWalletUserWalletIdEpayRequestComission, getUserWalletUserWalletIdPermittedsubusers, getUserWalletUserWalletIdSettlementRequestComission, getUserWalletUserWalletIdTransferMoneyCommission, getUserWorkspace, putBusinessUserConnectionConnectionId, putBusinessUserConnectionConnectionIdPermissionUserWalletId, putGroupTransferAdd, putNotificationIaNotifIdDismiss, putSubDomain, putUser, putUserBankUserBankId, putUserBankUserBankIdChangeVisibility, putUserChangeAvatar, putUserPluginUserPluginIdChangeStatus, putUserWalletUserWalletId, putUserWalletUserWalletIdNotification,}  from \\"./services\\"
+
+    export type SwaggerTypescriptMutationDefaultParams<TExtra> = {_extraVariables?:TExtra, configOverride?:AxiosRequestConfig}
+    type SwaggerTypescriptUseQueryOptions<TData> = Omit<UseQueryOptions<SwaggerResponse<TData>,RequestError | Error>,\\"queryKey\\">;
+
+    type SwaggerTypescriptUseMutationOptions<TData, TRequest, TExtra> = UseMutationOptions<
+      SwaggerResponse<TData>,
+      RequestError | Error,
+      TRequest & SwaggerTypescriptMutationDefaultParams<TExtra>
+    >;
+
+    type SwaggerTypescriptUseMutationOptionsVoid<
+      TData,
+      TExtra
+    > = UseMutationOptions<
+      SwaggerResponse<TData>,
+      RequestError | Error,
+      SwaggerTypescriptMutationDefaultParams<TExtra> | void
+    >;  
+    
+      
+/**
+ * 
+ * Disconnect sub user connection
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const useDeleteBusinessUserConnectionConnectionId =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (SubUserConnectionApiModel), {
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { connectionId,
+          
+          
+           configOverride } = _o || {};
+
+            return deleteBusinessUserConnectionConnectionId(
+                 connectionId,
+          
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      export const useDeleteBusinessUserConnectionConnectionIdPermissionUserWalletId =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions<string, {connectionId: number,
+/**
+ * 
+ * Id of Account to delete it's permissios
+ */
+userWalletId: number,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { connectionId,userWalletId,
+          
+          
+           configOverride } = _o || {};
+
+            return deleteBusinessUserConnectionConnectionIdPermissionUserWalletId(
+                 connectionId,userWalletId,
+          
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      
+/**
+ * 
+ * Remove an invitation
+[Feature just allowed for the business users]
+[Needs secure login]
+[Deprecated, use 'businessuser/invite/{invitationId}/remove' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useDeleteBusinessUserConnectionInvitationIdRemove =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (SubUserConnectionApiModel), {invitationId: string,queryParams?: DeleteBusinessUserConnectionInvitationIdRemoveQueryParams,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { invitationId,
+          
+          queryParams,
+           configOverride } = _o || {};
+
+            return deleteBusinessUserConnectionInvitationIdRemove(
+                 invitationId,
+          
+          queryParams,
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      
+/**
+ * 
+ * Remove an invitation
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const useDeleteBusinessUserInviteInvitationIdRemove =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (SubUserConnectionApiModel), {invitationId: number,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { invitationId,
+          
+          
+           configOverride } = _o || {};
+
+            return deleteBusinessUserInviteInvitationIdRemove(
+                 invitationId,
+          
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      
+/**
+ * 
+ * Disconnect business user connection
+[Feature just allowed for SubUsers]
+[Needs secure login]
+[Deprecated, use 'user/connection/{connectionId}' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useDeleteSubUserConnectionConnectionId =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (BusinessUserConnectionApiModel), {
+/**
+ * 
+ * connection id
+ */
+connectionId: number,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { connectionId,
+          
+          
+           configOverride } = _o || {};
+
+            return deleteSubUserConnectionConnectionId(
+                 connectionId,
+          
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      
+/**
+ * 
+ * Disconnect business user connection
+[Feature just allowed for normal users]
+[Needs secure login]
+ */
+export const useDeleteUserConnectionConnectionId =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (BusinessUserConnectionApiModel), {
+/**
+ * 
+ * connection id
+ */
+connectionId: number,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { connectionId,
+          
+          
+           configOverride } = _o || {};
+
+            return deleteUserConnectionConnectionId(
+                 connectionId,
+          
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      export const useGetAccessUserWalletIdLogicalAction = (
+           userWalletId: number,logicalAction: \\"EpayRequest\\" | \\"TransferMoney\\" | \\"AccountChargeRequest\\" | \\"ServiceBill\\" | \\"ServiceMobileCharge\\" | \\"POS\\" | \\"ShareAndBlockRequest\\" | \\"ShareRequest\\" | \\"Settlement\\" | \\"GroupTransferMoney\\" | \\"ShareAndUnblock\\" | \\"Refund\\" | \\"PayCommand\\" | \\"Gift\\" | \\"TaxiFairPayment\\" | \\"HitoBitFee\\",options?:SwaggerTypescriptUseQueryOptions<boolean>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetAccessUserWalletIdLogicalAction.info( userWalletId,logicalAction,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetAccessUserWalletIdLogicalAction.info = (userWalletId: number,logicalAction: \\"EpayRequest\\" | \\"TransferMoney\\" | \\"AccountChargeRequest\\" | \\"ServiceBill\\" | \\"ServiceMobileCharge\\" | \\"POS\\" | \\"ShareAndBlockRequest\\" | \\"ShareRequest\\" | \\"Settlement\\" | \\"GroupTransferMoney\\" | \\"ShareAndUnblock\\" | \\"Refund\\" | \\"PayCommand\\" | \\"Gift\\" | \\"TaxiFairPayment\\" | \\"HitoBitFee\\",configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getAccessUserWalletIdLogicalAction.key,userWalletId,logicalAction,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getAccessUserWalletIdLogicalAction(
+                   userWalletId,logicalAction,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetAccessUserWalletIdLogicalAction.prefetch = (
+            client: QueryClient,
+            userWalletId: number,logicalAction: \\"EpayRequest\\" | \\"TransferMoney\\" | \\"AccountChargeRequest\\" | \\"ServiceBill\\" | \\"ServiceMobileCharge\\" | \\"POS\\" | \\"ShareAndBlockRequest\\" | \\"ShareRequest\\" | \\"Settlement\\" | \\"GroupTransferMoney\\" | \\"ShareAndUnblock\\" | \\"Refund\\" | \\"PayCommand\\" | \\"Gift\\" | \\"TaxiFairPayment\\" | \\"HitoBitFee\\",options?:SwaggerTypescriptUseQueryOptions<boolean>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetAccessUserWalletIdLogicalAction.info( userWalletId,logicalAction,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get available banks
+ */
+export const useGetBank = (
+           options?:SwaggerTypescriptUseQueryOptions<BankApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBank.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBank.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBank.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getBank(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetBank.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<BankApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBank.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get Business categories
+ */
+export const useGetBusinessUserCategory = (
+           options?:SwaggerTypescriptUseQueryOptions<BusinessCategoryApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBusinessUserCategory.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBusinessUserCategory.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBusinessUserCategory.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getBusinessUserCategory(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetBusinessUserCategory.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<BusinessCategoryApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBusinessUserCategory.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the connections
+[Feature just allowed for the business users]
+ */
+export const useGetBusinessUserConnection = (
+           queryParams?: GetBusinessUserConnectionQueryParams,options?:SwaggerTypescriptUseQueryOptions<SubUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBusinessUserConnection.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBusinessUserConnection.info = (queryParams?: GetBusinessUserConnectionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBusinessUserConnection.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getBusinessUserConnection(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetBusinessUserConnection.prefetch = (
+            client: QueryClient,
+            queryParams?: GetBusinessUserConnectionQueryParams,options?:SwaggerTypescriptUseQueryOptions<SubUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBusinessUserConnection.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get active connections ordered by Transactions count
+[Feature just allowed for the business users]
+ */
+export const useGetBusinessUserConnectionActive = (
+           queryParams?: GetBusinessUserConnectionActiveQueryParams,options?:SwaggerTypescriptUseQueryOptions<SubUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBusinessUserConnectionActive.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBusinessUserConnectionActive.info = (queryParams?: GetBusinessUserConnectionActiveQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBusinessUserConnectionActive.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getBusinessUserConnectionActive(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetBusinessUserConnectionActive.prefetch = (
+            client: QueryClient,
+            queryParams?: GetBusinessUserConnectionActiveQueryParams,options?:SwaggerTypescriptUseQueryOptions<SubUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBusinessUserConnectionActive.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the connection detail
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const useGetBusinessUserConnectionConnectionId = (
+           
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,options?:SwaggerTypescriptUseQueryOptions< & (SubUserConnectionApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBusinessUserConnectionConnectionId.info( connectionId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBusinessUserConnectionConnectionId.info = (
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBusinessUserConnectionConnectionId.key,connectionId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getBusinessUserConnectionConnectionId(
+                   connectionId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetBusinessUserConnectionConnectionId.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,options?:SwaggerTypescriptUseQueryOptions< & (SubUserConnectionApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBusinessUserConnectionConnectionId.info( connectionId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the connection amounts report
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const useGetBusinessUserConnectionConnectionIdActivity = (
+           
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,options?:SwaggerTypescriptUseQueryOptions< & (SubUserActivityApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBusinessUserConnectionConnectionIdActivity.info( connectionId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBusinessUserConnectionConnectionIdActivity.info = (
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBusinessUserConnectionConnectionIdActivity.key,connectionId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getBusinessUserConnectionConnectionIdActivity(
+                   connectionId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetBusinessUserConnectionConnectionIdActivity.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,options?:SwaggerTypescriptUseQueryOptions< & (SubUserActivityApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBusinessUserConnectionConnectionIdActivity.info( connectionId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetBusinessUserConnectionConnectionIdEpay = (
+           connectionId: number,queryParams?: GetBusinessUserConnectionConnectionIdEpayQueryParams,options?:SwaggerTypescriptUseQueryOptions<EpayRequestApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBusinessUserConnectionConnectionIdEpay.info( connectionId,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBusinessUserConnectionConnectionIdEpay.info = (connectionId: number,queryParams?: GetBusinessUserConnectionConnectionIdEpayQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBusinessUserConnectionConnectionIdEpay.key,connectionId,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getBusinessUserConnectionConnectionIdEpay(
+                   connectionId,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetBusinessUserConnectionConnectionIdEpay.prefetch = (
+            client: QueryClient,
+            connectionId: number,queryParams?: GetBusinessUserConnectionConnectionIdEpayQueryParams,options?:SwaggerTypescriptUseQueryOptions<EpayRequestApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBusinessUserConnectionConnectionIdEpay.info( connectionId,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get sub user permissions for accounts
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const useGetBusinessUserConnectionConnectionIdPermission = (
+           
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,options?:SwaggerTypescriptUseQueryOptions<SubUserPermissionApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBusinessUserConnectionConnectionIdPermission.info( connectionId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBusinessUserConnectionConnectionIdPermission.info = (
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBusinessUserConnectionConnectionIdPermission.key,connectionId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getBusinessUserConnectionConnectionIdPermission(
+                   connectionId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetBusinessUserConnectionConnectionIdPermission.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,options?:SwaggerTypescriptUseQueryOptions<SubUserPermissionApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBusinessUserConnectionConnectionIdPermission.info( connectionId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequest = (
+           queryParams?: GetEpayRequestQueryParams,options?:SwaggerTypescriptUseQueryOptions<EpayRequestApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequest.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequest.info = (queryParams?: GetEpayRequestQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequest.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequest(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequest.prefetch = (
+            client: QueryClient,
+            queryParams?: GetEpayRequestQueryParams,options?:SwaggerTypescriptUseQueryOptions<EpayRequestApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequest.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestAudiencesRecent = (
+           options?:SwaggerTypescriptUseQueryOptions<ContactApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestAudiencesRecent.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestAudiencesRecent.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestAudiencesRecent.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestAudiencesRecent(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestAudiencesRecent.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<ContactApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestAudiencesRecent.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestCount = (
+           queryParams?: GetEpayRequestCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestCount.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestCount.info = (queryParams?: GetEpayRequestCountQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestCount.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestCount(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestCount.prefetch = (
+            client: QueryClient,
+            queryParams?: GetEpayRequestCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestCount.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get epay request detail based on Id
+ */
+export const useGetEpayRequestEpayId = (
+           
+/**
+ * 
+ * EpayRequest's Id
+ */
+epayId: number,options?:SwaggerTypescriptUseQueryOptions< & (EpayRequestDetailApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestEpayId.info( epayId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestEpayId.info = (
+/**
+ * 
+ * EpayRequest's Id
+ */
+epayId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestEpayId.key,epayId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestEpayId(
+                   epayId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestEpayId.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * EpayRequest's Id
+ */
+epayId: number,options?:SwaggerTypescriptUseQueryOptions< & (EpayRequestDetailApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestEpayId.info( epayId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestEpayTokenDetail = (
+           epayToken: string,options?:SwaggerTypescriptUseQueryOptions< & (EpayRequestPublicInfoApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestEpayTokenDetail.info( epayToken,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestEpayTokenDetail.info = (epayToken: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestEpayTokenDetail.key,epayToken,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestEpayTokenDetail(
+                   epayToken,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestEpayTokenDetail.prefetch = (
+            client: QueryClient,
+            epayToken: string,options?:SwaggerTypescriptUseQueryOptions< & (EpayRequestPublicInfoApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestEpayTokenDetail.info( epayToken,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get QR code image file for epay request
+ */
+export const useGetEpayRequestEpayTokenQrcode = (
+           
+/**
+ * 
+ * epay request token
+ */
+epayToken: string,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestEpayTokenQrcode.info( epayToken,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestEpayTokenQrcode.info = (
+/**
+ * 
+ * epay request token
+ */
+epayToken: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestEpayTokenQrcode.key,epayToken,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestEpayTokenQrcode(
+                   epayToken,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestEpayTokenQrcode.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * epay request token
+ */
+epayToken: string,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestEpayTokenQrcode.info( epayToken,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestExcel = (
+           queryParams?: GetEpayRequestExcelQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestExcel.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestExcel.info = (queryParams?: GetEpayRequestExcelQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestExcel.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestExcel(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestExcel.prefetch = (
+            client: QueryClient,
+            queryParams?: GetEpayRequestExcelQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestExcel.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get pay requests that the user is one of its audiences.
+[Feature is not allowed for sub users]
+[Needs secure login]
+ */
+export const useGetEpayRequestForMe = (
+           queryParams?: GetEpayRequestForMeQueryParams,options?:SwaggerTypescriptUseQueryOptions<EpayRequestForUserQuery[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestForMe.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestForMe.info = (queryParams?: GetEpayRequestForMeQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestForMe.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestForMe(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestForMe.prefetch = (
+            client: QueryClient,
+            queryParams?: GetEpayRequestForMeQueryParams,options?:SwaggerTypescriptUseQueryOptions<EpayRequestForUserQuery[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestForMe.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestForMeCount = (
+           queryParams?: GetEpayRequestForMeCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestForMeCount.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestForMeCount.info = (queryParams?: GetEpayRequestForMeCountQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestForMeCount.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestForMeCount(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestForMeCount.prefetch = (
+            client: QueryClient,
+            queryParams?: GetEpayRequestForMeCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestForMeCount.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestForMeReport = (
+           queryParams?: GetEpayRequestForMeReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReportApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestForMeReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestForMeReport.info = (queryParams?: GetEpayRequestForMeReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestForMeReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestForMeReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestForMeReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetEpayRequestForMeReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReportApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestForMeReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * [Deprecated, use 'account/{accountNumber}/qrcode' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetEpayRequestPosQrAccountNumber = (
+           accountNumber: string,queryParams?: GetEpayRequestPosQrAccountNumberQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestPosQrAccountNumber.info( accountNumber,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestPosQrAccountNumber.info = (accountNumber: string,queryParams?: GetEpayRequestPosQrAccountNumberQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestPosQrAccountNumber.key,accountNumber,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestPosQrAccountNumber(
+                   accountNumber,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestPosQrAccountNumber.prefetch = (
+            client: QueryClient,
+            accountNumber: string,queryParams?: GetEpayRequestPosQrAccountNumberQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestPosQrAccountNumber.info( accountNumber,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestReport = (
+           queryParams?: GetEpayRequestReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReportApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestReport.info = (queryParams?: GetEpayRequestReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetEpayRequestReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReportApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get comission amount for epay request amount
+ */
+export const useGetEpayRequestUserWalletIdCommission = (
+           userWalletId: number,queryParams?: GetEpayRequestUserWalletIdCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestUserWalletIdCommission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestUserWalletIdCommission.info = (userWalletId: number,queryParams?: GetEpayRequestUserWalletIdCommissionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestUserWalletIdCommission.key,userWalletId,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestUserWalletIdCommission(
+                   userWalletId,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestUserWalletIdCommission.prefetch = (
+            client: QueryClient,
+            userWalletId: number,queryParams?: GetEpayRequestUserWalletIdCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestUserWalletIdCommission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestUserWalletIdCreators = (
+           userWalletId: number,options?:SwaggerTypescriptUseQueryOptions<UserMinimalDto[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestUserWalletIdCreators.info( userWalletId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestUserWalletIdCreators.info = (userWalletId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestUserWalletIdCreators.key,userWalletId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestUserWalletIdCreators(
+                   userWalletId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestUserWalletIdCreators.prefetch = (
+            client: QueryClient,
+            userWalletId: number,options?:SwaggerTypescriptUseQueryOptions<UserMinimalDto[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestUserWalletIdCreators.info( userWalletId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetError = (
+           options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetError.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetError.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getError.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getError(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetError.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetError.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetErrorLocal = (
+           options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetErrorLocal.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetErrorLocal.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getErrorLocal.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getErrorLocal(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetErrorLocal.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetErrorLocal.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetErrorStatusCode = (
+           code: number,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetErrorStatusCode.info( code,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetErrorStatusCode.info = (code: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getErrorStatusCode.key,code,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getErrorStatusCode(
+                   code,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetErrorStatusCode.prefetch = (
+            client: QueryClient,
+            code: number,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetErrorStatusCode.info( code,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Download a file.
+ */
+export const useGetFileFileGuid = (
+           
+/**
+ * 
+ * file unique id
+ */
+fileGuid: string,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetFileFileGuid.info( fileGuid,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetFileFileGuid.info = (
+/**
+ * 
+ * file unique id
+ */
+fileGuid: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getFileFileGuid.key,fileGuid,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getFileFileGuid(
+                   fileGuid,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetFileFileGuid.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * file unique id
+ */
+fileGuid: string,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetFileFileGuid.info( fileGuid,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetGroupTransferCommission = (
+           queryParams?: GetGroupTransferCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetGroupTransferCommission.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetGroupTransferCommission.info = (queryParams?: GetGroupTransferCommissionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getGroupTransferCommission.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getGroupTransferCommission(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetGroupTransferCommission.prefetch = (
+            client: QueryClient,
+            queryParams?: GetGroupTransferCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetGroupTransferCommission.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get detailed driver,taxi and fair amount information
+ */
+export const useGetIntegration = (
+           queryParams?: GetIntegrationQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (DriverInfoResult)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetIntegration.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetIntegration.info = (queryParams?: GetIntegrationQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getIntegration.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getIntegration(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetIntegration.prefetch = (
+            client: QueryClient,
+            queryParams?: GetIntegrationQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (DriverInfoResult)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetIntegration.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetKpi = (
+           queryParams?: GetKpiQueryParams,options?:SwaggerTypescriptUseQueryOptions<KpiResult[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetKpi.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetKpi.info = (queryParams?: GetKpiQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getKpi.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getKpi(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetKpi.prefetch = (
+            client: QueryClient,
+            queryParams?: GetKpiQueryParams,options?:SwaggerTypescriptUseQueryOptions<KpiResult[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetKpi.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetKpiCurrent = (
+           queryParams?: GetKpiCurrentQueryParams,options?:SwaggerTypescriptUseQueryOptions<KpiResult[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetKpiCurrent.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetKpiCurrent.info = (queryParams?: GetKpiCurrentQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getKpiCurrent.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getKpiCurrent(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetKpiCurrent.prefetch = (
+            client: QueryClient,
+            queryParams?: GetKpiCurrentQueryParams,options?:SwaggerTypescriptUseQueryOptions<KpiResult[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetKpiCurrent.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetKpiLast = (
+           queryParams?: GetKpiLastQueryParams,options?:SwaggerTypescriptUseQueryOptions<KpiResult[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetKpiLast.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetKpiLast.info = (queryParams?: GetKpiLastQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getKpiLast.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getKpiLast(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetKpiLast.prefetch = (
+            client: QueryClient,
+            queryParams?: GetKpiLastQueryParams,options?:SwaggerTypescriptUseQueryOptions<KpiResult[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetKpiLast.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get all Important Actions of current user.
+ */
+export const useGetNotificationIa = (
+           options?:SwaggerTypescriptUseQueryOptions<ImportantActionApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetNotificationIa.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetNotificationIa.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getNotificationIa.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getNotificationIa(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetNotificationIa.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<ImportantActionApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetNotificationIa.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get Notifications of current user.
+Maximum 99 items will be returned.
+ */
+export const useGetNotificationNotif = (
+           options?:SwaggerTypescriptUseQueryOptions<NotificationApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetNotificationNotif.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetNotificationNotif.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getNotificationNotif.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getNotificationNotif(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetNotificationNotif.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<NotificationApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetNotificationNotif.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetNotificationUnread = (
+           queryParams?: GetNotificationUnreadQueryParams,options?:SwaggerTypescriptUseQueryOptions<UnreadNotificationCountApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetNotificationUnread.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetNotificationUnread.info = (queryParams?: GetNotificationUnreadQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getNotificationUnread.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getNotificationUnread(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetNotificationUnread.prefetch = (
+            client: QueryClient,
+            queryParams?: GetNotificationUnreadQueryParams,options?:SwaggerTypescriptUseQueryOptions<UnreadNotificationCountApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetNotificationUnread.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetPluginPluginId = (
+           pluginId: number,options?:SwaggerTypescriptUseQueryOptions< & (PluginApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetPluginPluginId.info( pluginId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetPluginPluginId.info = (pluginId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getPluginPluginId.key,pluginId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getPluginPluginId(
+                   pluginId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetPluginPluginId.prefetch = (
+            client: QueryClient,
+            pluginId: number,options?:SwaggerTypescriptUseQueryOptions< & (PluginApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetPluginPluginId.info( pluginId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get epay request detail
+ */
+export const useGetPosAccountNumber = (
+           
+/**
+ * 
+ * Account Number
+ */
+accountNumber: string,queryParams?: GetPosAccountNumberQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (PosLandingPageApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetPosAccountNumber.info( accountNumber,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetPosAccountNumber.info = (
+/**
+ * 
+ * Account Number
+ */
+accountNumber: string,queryParams?: GetPosAccountNumberQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getPosAccountNumber.key,accountNumber,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getPosAccountNumber(
+                   accountNumber,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetPosAccountNumber.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * Account Number
+ */
+accountNumber: string,queryParams?: GetPosAccountNumberQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (PosLandingPageApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetPosAccountNumber.info( accountNumber,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get bank receipt by EPayTry id
+[For anonymous users]
+ */
+export const useGetReceiptBankEpayTryId = (
+           
+/**
+ * 
+ * EpayTry's id to get receipt for
+ */
+epayTryId: string,options?:SwaggerTypescriptUseQueryOptions< & (BankReceiptApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetReceiptBankEpayTryId.info( epayTryId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetReceiptBankEpayTryId.info = (
+/**
+ * 
+ * EpayTry's id to get receipt for
+ */
+epayTryId: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getReceiptBankEpayTryId.key,epayTryId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getReceiptBankEpayTryId(
+                   epayTryId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetReceiptBankEpayTryId.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * EpayTry's id to get receipt for
+ */
+epayTryId: string,options?:SwaggerTypescriptUseQueryOptions< & (BankReceiptApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetReceiptBankEpayTryId.info( epayTryId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get bank receipt by EPayRequest token
+[For anonymous users]
+[Deprecated, use 'receipt/bank/{epayTryId}' and 'receipt/bank/{epayTryId}' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetReceiptEpayToken = (
+           
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,options?:SwaggerTypescriptUseQueryOptions< & (BankReceiptApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetReceiptEpayToken.info( epayToken,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetReceiptEpayToken.info = (
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getReceiptEpayToken.key,epayToken,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getReceiptEpayToken(
+                   epayToken,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetReceiptEpayToken.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,options?:SwaggerTypescriptUseQueryOptions< & (BankReceiptApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetReceiptEpayToken.info( epayToken,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get wallet receipt by EPayRequest token
+[For anonymous users]
+ */
+export const useGetReceiptWalletEpayToken = (
+           
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,options?:SwaggerTypescriptUseQueryOptions< & (WalletReceiptApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetReceiptWalletEpayToken.info( epayToken,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetReceiptWalletEpayToken.info = (
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getReceiptWalletEpayToken.key,epayToken,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getReceiptWalletEpayToken(
+                   epayToken,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetReceiptWalletEpayToken.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,options?:SwaggerTypescriptUseQueryOptions< & (WalletReceiptApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetReceiptWalletEpayToken.info( epayToken,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the Resellership info of current Reseller user
+[Feature just allowed for Resellers]
+ */
+export const useGetResellerUser = (
+           options?:SwaggerTypescriptUseQueryOptions< & (ResellerApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUser.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUser.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUser.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getResellerUser(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUser.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions< & (ResellerApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUser.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the time-based report of commissions paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardCommissionReport = (
+           queryParams?: GetResellerUserDashboardCommissionReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfDecimal[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardCommissionReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardCommissionReport.info = (queryParams?: GetResellerUserDashboardCommissionReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardCommissionReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardCommissionReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardCommissionReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardCommissionReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfDecimal[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardCommissionReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get sum of all commissions paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardCommissionSum = (
+           queryParams?: GetResellerUserDashboardCommissionSumQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardCommissionSum.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardCommissionSum.info = (queryParams?: GetResellerUserDashboardCommissionSumQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardCommissionSum.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardCommissionSum(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardCommissionSum.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardCommissionSumQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardCommissionSum.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get count of all users reselled by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardIntroducedCount = (
+           queryParams?: GetResellerUserDashboardIntroducedCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardIntroducedCount.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardIntroducedCount.info = (queryParams?: GetResellerUserDashboardIntroducedCountQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardIntroducedCount.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardIntroducedCount(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardIntroducedCount.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardIntroducedCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardIntroducedCount.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get time-based report of users reselled by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardIntroducedReport = (
+           queryParams?: GetResellerUserDashboardIntroducedReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardIntroducedReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardIntroducedReport.info = (queryParams?: GetResellerUserDashboardIntroducedReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardIntroducedReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardIntroducedReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardIntroducedReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardIntroducedReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardIntroducedReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get count of all links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardLinksCount = (
+           queryParams?: GetResellerUserDashboardLinksCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardLinksCount.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardLinksCount.info = (queryParams?: GetResellerUserDashboardLinksCountQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardLinksCount.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardLinksCount(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardLinksCount.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardLinksCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardLinksCount.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get count of all paid links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardLinksPaidCount = (
+           queryParams?: GetResellerUserDashboardLinksPaidCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardLinksPaidCount.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardLinksPaidCount.info = (queryParams?: GetResellerUserDashboardLinksPaidCountQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardLinksPaidCount.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardLinksPaidCount(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardLinksPaidCount.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardLinksPaidCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardLinksPaidCount.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get time-based report of paid links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardLinksPaidReport = (
+           queryParams?: GetResellerUserDashboardLinksPaidReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardLinksPaidReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardLinksPaidReport.info = (queryParams?: GetResellerUserDashboardLinksPaidReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardLinksPaidReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardLinksPaidReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardLinksPaidReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardLinksPaidReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardLinksPaidReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get time-based report of links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardLinksReport = (
+           queryParams?: GetResellerUserDashboardLinksReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardLinksReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardLinksReport.info = (queryParams?: GetResellerUserDashboardLinksReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardLinksReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardLinksReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardLinksReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardLinksReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardLinksReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get count of all commission transactions, paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardTransactionsCount = (
+           queryParams?: GetResellerUserDashboardTransactionsCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardTransactionsCount.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardTransactionsCount.info = (queryParams?: GetResellerUserDashboardTransactionsCountQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardTransactionsCount.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardTransactionsCount(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardTransactionsCount.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardTransactionsCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardTransactionsCount.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get time-based report of commission transactions, paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardTransactionsReport = (
+           queryParams?: GetResellerUserDashboardTransactionsReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardTransactionsReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardTransactionsReport.info = (queryParams?: GetResellerUserDashboardTransactionsReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardTransactionsReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardTransactionsReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardTransactionsReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardTransactionsReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardTransactionsReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the Users Introduced by current Reseller user
+[Feature just allowed for Resellers]
+ */
+export const useGetResellerUserIntroduced = (
+           queryParams?: GetResellerUserIntroducedQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReselledUserApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserIntroduced.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserIntroduced.info = (queryParams?: GetResellerUserIntroducedQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserIntroduced.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserIntroduced(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserIntroduced.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserIntroducedQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReselledUserApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserIntroduced.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get filter data items to populate DropDowns
+[Feature just allowed for Resellers]
+ */
+export const useGetResellerUserIntroducedFilterData = (
+           options?:SwaggerTypescriptUseQueryOptions< & (ReselledUserFilterData)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserIntroducedFilterData.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserIntroducedFilterData.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserIntroducedFilterData.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserIntroducedFilterData(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserIntroducedFilterData.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions< & (ReselledUserFilterData)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserIntroducedFilterData.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the User activity
+[Feature just allowed for Resellers]
+ */
+export const useGetResellerUserIntroducedUserIdActivity = (
+           userId: string,options?:SwaggerTypescriptUseQueryOptions< & (ReselledUserActivityApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserIntroducedUserIdActivity.info( userId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserIntroducedUserIdActivity.info = (userId: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserIntroducedUserIdActivity.key,userId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserIntroducedUserIdActivity(
+                   userId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserIntroducedUserIdActivity.prefetch = (
+            client: QueryClient,
+            userId: string,options?:SwaggerTypescriptUseQueryOptions< & (ReselledUserActivityApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserIntroducedUserIdActivity.info( userId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the SubDomain of current Reseller user
+[Feature just allowed for Resellers]
+ */
+export const useGetSubDomain = (
+           options?:SwaggerTypescriptUseQueryOptions< & (SubDomainApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetSubDomain.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetSubDomain.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getSubDomain.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getSubDomain(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetSubDomain.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions< & (SubDomainApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetSubDomain.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get info of a SubDomain by it's address.
+ */
+export const useGetSubDomainSubDomainAddress = (
+           
+/**
+ * 
+ * The SubDomain part of the url.
+            
+ */
+subDomainAddress: string,headerParams?: {
+/**
+ * 
+ * - Format: guid
+ */
+\\"clientId\\": string;},options?:SwaggerTypescriptUseQueryOptions< & (SubDomainApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetSubDomainSubDomainAddress.info( subDomainAddress,
+          
+          
+          headerParams, configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetSubDomainSubDomainAddress.info = (
+/**
+ * 
+ * The SubDomain part of the url.
+            
+ */
+subDomainAddress: string,headerParams?: {
+/**
+ * 
+ * - Format: guid
+ */
+\\"clientId\\": string;},configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getSubDomainSubDomainAddress.key,subDomainAddress,
+            
+            
+            headerParams,] as QueryKey,
+                fun: () =>
+                getSubDomainSubDomainAddress(
+                   subDomainAddress,
+          
+          
+          headerParams,
+                  configOverride
+                ),
+              };
+            };useGetSubDomainSubDomainAddress.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * The SubDomain part of the url.
+            
+ */
+subDomainAddress: string,headerParams?: {
+/**
+ * 
+ * - Format: guid
+ */
+\\"clientId\\": string;},options?:SwaggerTypescriptUseQueryOptions< & (SubDomainApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetSubDomainSubDomainAddress.info( subDomainAddress,
+          
+          
+          headerParams, configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get permission details of an Account
+[Feature just allowed for SubUsers]
+ */
+export const useGetSubUserAccountUserWalletId = (
+           userWalletId: number,options?:SwaggerTypescriptUseQueryOptions< & (SubUserAccountDetailQuery)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetSubUserAccountUserWalletId.info( userWalletId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetSubUserAccountUserWalletId.info = (userWalletId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getSubUserAccountUserWalletId.key,userWalletId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getSubUserAccountUserWalletId(
+                   userWalletId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetSubUserAccountUserWalletId.prefetch = (
+            client: QueryClient,
+            userWalletId: number,options?:SwaggerTypescriptUseQueryOptions< & (SubUserAccountDetailQuery)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetSubUserAccountUserWalletId.info( userWalletId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the connections
+[Feature just allowed for SubUsers]
+[Deprecated. use 'user/connection' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetSubUserConnection = (
+           options?:SwaggerTypescriptUseQueryOptions<BusinessUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetSubUserConnection.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetSubUserConnection.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getSubUserConnection.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getSubUserConnection(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetSubUserConnection.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<BusinessUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetSubUserConnection.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetTransaction = (
+           queryParams?: GetTransactionQueryParams,options?:SwaggerTypescriptUseQueryOptions<TransactionApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransaction.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransaction.info = (queryParams?: GetTransactionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransaction.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getTransaction(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetTransaction.prefetch = (
+            client: QueryClient,
+            queryParams?: GetTransactionQueryParams,options?:SwaggerTypescriptUseQueryOptions<TransactionApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransaction.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetTransactionExcel = (
+           queryParams?: GetTransactionExcelQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransactionExcel.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransactionExcel.info = (queryParams?: GetTransactionExcelQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransactionExcel.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getTransactionExcel(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetTransactionExcel.prefetch = (
+            client: QueryClient,
+            queryParams?: GetTransactionExcelQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransactionExcel.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetTransactionReport = (
+           queryParams?: GetTransactionReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReportApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransactionReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransactionReport.info = (queryParams?: GetTransactionReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransactionReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getTransactionReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetTransactionReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetTransactionReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReportApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransactionReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetTransactionReportAll = (
+           queryParams?: GetTransactionReportAllQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AllTransactionsReportApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransactionReportAll.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransactionReportAll.info = (queryParams?: GetTransactionReportAllQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransactionReportAll.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getTransactionReportAll(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetTransactionReportAll.prefetch = (
+            client: QueryClient,
+            queryParams?: GetTransactionReportAllQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AllTransactionsReportApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransactionReportAll.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get a Transaction by it's Id
+[Needs secure login]
+ */
+export const useGetTransactionTransactionId = (
+           transactionId: number,options?:SwaggerTypescriptUseQueryOptions< & (TransactionApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransactionTransactionId.info( transactionId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransactionTransactionId.info = (transactionId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransactionTransactionId.key,transactionId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getTransactionTransactionId(
+                   transactionId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetTransactionTransactionId.prefetch = (
+            client: QueryClient,
+            transactionId: number,options?:SwaggerTypescriptUseQueryOptions< & (TransactionApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransactionTransactionId.info( transactionId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get recent money transfers
+ */
+export const useGetTransferRecent = (
+           queryParams?: GetTransferRecentQueryParams,options?:SwaggerTypescriptUseQueryOptions<TransferMoneyApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransferRecent.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransferRecent.info = (queryParams?: GetTransferRecentQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransferRecent.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getTransferRecent(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetTransferRecent.prefetch = (
+            client: QueryClient,
+            queryParams?: GetTransferRecentQueryParams,options?:SwaggerTypescriptUseQueryOptions<TransferMoneyApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransferRecent.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetTransferSearch = (
+           queryParams?: GetTransferSearchQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AccountInfoApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransferSearch.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransferSearch.info = (queryParams?: GetTransferSearchQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransferSearch.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getTransferSearch(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetTransferSearch.prefetch = (
+            client: QueryClient,
+            queryParams?: GetTransferSearchQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AccountInfoApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransferSearch.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get commission amount for transfer money amount
+ */
+export const useGetTransferUserWalletIdCommission = (
+           userWalletId: number,queryParams?: GetTransferUserWalletIdCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransferUserWalletIdCommission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransferUserWalletIdCommission.info = (userWalletId: number,queryParams?: GetTransferUserWalletIdCommissionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransferUserWalletIdCommission.key,userWalletId,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getTransferUserWalletIdCommission(
+                   userWalletId,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetTransferUserWalletIdCommission.prefetch = (
+            client: QueryClient,
+            userWalletId: number,queryParams?: GetTransferUserWalletIdCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransferUserWalletIdCommission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get [normal/sub/business] user profile detail
+ */
+export const useGetUser = (
+           options?:SwaggerTypescriptUseQueryOptions< & (UserDetailQuery)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUser.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUser.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUser.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUser(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUser.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions< & (UserDetailQuery)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUser.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get user banks
+[Feature is not allowed for sub users.]
+ */
+export const useGetUserBank = (
+           options?:SwaggerTypescriptUseQueryOptions<UserBankApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserBank.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserBank.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserBank.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserBank(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserBank.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<UserBankApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserBank.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get available user banks
+[Feature is not allowed for sub users.]
+ */
+export const useGetUserBankReady = (
+           options?:SwaggerTypescriptUseQueryOptions<UserBankApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserBankReady.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserBankReady.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserBankReady.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserBankReady(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserBankReady.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<UserBankApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserBankReady.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * get user bank detail
+[Needs secure login]
+ */
+export const useGetUserBankUserBankId = (
+           
+/**
+ * 
+ * User bank id
+ */
+userBankId: number,options?:SwaggerTypescriptUseQueryOptions< & (UserBankDetailApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserBankUserBankId.info( userBankId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserBankUserBankId.info = (
+/**
+ * 
+ * User bank id
+ */
+userBankId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserBankUserBankId.key,userBankId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserBankUserBankId(
+                   userBankId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserBankUserBankId.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * User bank id
+ */
+userBankId: number,options?:SwaggerTypescriptUseQueryOptions< & (UserBankDetailApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserBankUserBankId.info( userBankId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the connections [Feature is allowed for normal users noly]
+ */
+export const useGetUserConnection = (
+           options?:SwaggerTypescriptUseQueryOptions<BusinessUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserConnection.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserConnection.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserConnection.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserConnection(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserConnection.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<BusinessUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserConnection.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetUserContactInput = (
+           input: string,options?:SwaggerTypescriptUseQueryOptions< & (ContactApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserContactInput.info( input,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserContactInput.info = (input: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserContactInput.key,input,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserContactInput(
+                   input,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserContactInput.prefetch = (
+            client: QueryClient,
+            input: string,options?:SwaggerTypescriptUseQueryOptions< & (ContactApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserContactInput.info( input,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get last national id verification request [Feature is not allowed for sub users]
+ */
+export const useGetUserIdentityRequest = (
+           options?:SwaggerTypescriptUseQueryOptions< & (UserIdentityRequestQuery)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserIdentityRequest.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserIdentityRequest.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserIdentityRequest.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserIdentityRequest(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserIdentityRequest.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions< & (UserIdentityRequestQuery)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserIdentityRequest.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get business user invitations for me [Feature is not allowed for sub users]
+ */
+export const useGetUserInvitation = (
+           options?:SwaggerTypescriptUseQueryOptions<SubUserInvitationApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserInvitation.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserInvitation.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserInvitation.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserInvitation(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserInvitation.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<SubUserInvitationApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserInvitation.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get business user invitations for me [Feature is not allowed for sub users]
+ */
+export const useGetUserInvitationInvitationToken = (
+           invitationToken: string,options?:SwaggerTypescriptUseQueryOptions< & (SubUserInvitationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserInvitationInvitationToken.info( invitationToken,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserInvitationInvitationToken.info = (invitationToken: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserInvitationInvitationToken.key,invitationToken,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserInvitationInvitationToken(
+                   invitationToken,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserInvitationInvitationToken.prefetch = (
+            client: QueryClient,
+            invitationToken: string,options?:SwaggerTypescriptUseQueryOptions< & (SubUserInvitationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserInvitationInvitationToken.info( invitationToken,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get user profile summary
+ */
+export const useGetUserMe = (
+           options?:SwaggerTypescriptUseQueryOptions< & (UserMeQuery)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserMe.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserMe.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserMe.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserMe(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserMe.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions< & (UserMeQuery)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserMe.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetUserPlugin = (
+           options?:SwaggerTypescriptUseQueryOptions<UserPluginDetailApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserPlugin.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserPlugin.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserPlugin.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserPlugin(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserPlugin.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<UserPluginDetailApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserPlugin.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get Last Request for upgrade account to the business [Feature is allowed for normal users only]
+ */
+export const useGetUserUpgradeToBusinessRequest = (
+           options?:SwaggerTypescriptUseQueryOptions< & (UpgradeToBusinessApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserUpgradeToBusinessRequest.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserUpgradeToBusinessRequest.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserUpgradeToBusinessRequest.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserUpgradeToBusinessRequest(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserUpgradeToBusinessRequest.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions< & (UpgradeToBusinessApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserUpgradeToBusinessRequest.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetUserWallet = (
+           options?:SwaggerTypescriptUseQueryOptions<WalletDisplayApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWallet.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWallet.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWallet.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserWallet(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWallet.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<WalletDisplayApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWallet.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetUserWalletAccountNumberQrcode = (
+           accountNumber: string,queryParams?: GetUserWalletAccountNumberQrcodeQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletAccountNumberQrcode.info( accountNumber,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletAccountNumberQrcode.info = (accountNumber: string,queryParams?: GetUserWalletAccountNumberQrcodeQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletAccountNumberQrcode.key,accountNumber,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletAccountNumberQrcode(
+                   accountNumber,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletAccountNumberQrcode.prefetch = (
+            client: QueryClient,
+            accountNumber: string,queryParams?: GetUserWalletAccountNumberQrcodeQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletAccountNumberQrcode.info( accountNumber,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetUserWalletSearch = (
+           queryParams?: GetUserWalletSearchQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AccountInfoApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletSearch.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletSearch.info = (queryParams?: GetUserWalletSearchQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletSearch.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletSearch(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletSearch.prefetch = (
+            client: QueryClient,
+            queryParams?: GetUserWalletSearchQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AccountInfoApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletSearch.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetUserWalletUserWalletId = (
+           userWalletId: number,options?:SwaggerTypescriptUseQueryOptions< & (WalletDetailApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletUserWalletId.info( userWalletId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletUserWalletId.info = (userWalletId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletUserWalletId.key,userWalletId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletUserWalletId(
+                   userWalletId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletUserWalletId.prefetch = (
+            client: QueryClient,
+            userWalletId: number,options?:SwaggerTypescriptUseQueryOptions< & (WalletDetailApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletUserWalletId.info( userWalletId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get user account balance
+ */
+export const useGetUserWalletUserWalletIdBalance = (
+           userWalletId: number,options?:SwaggerTypescriptUseQueryOptions< & (AccountBalanceApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletUserWalletIdBalance.info( userWalletId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletUserWalletIdBalance.info = (userWalletId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletUserWalletIdBalance.key,userWalletId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletUserWalletIdBalance(
+                   userWalletId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletUserWalletIdBalance.prefetch = (
+            client: QueryClient,
+            userWalletId: number,options?:SwaggerTypescriptUseQueryOptions< & (AccountBalanceApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletUserWalletIdBalance.info( userWalletId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetUserWalletUserWalletIdEpayRequestComission = (
+           userWalletId: number,queryParams?: GetUserWalletUserWalletIdEpayRequestComissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletUserWalletIdEpayRequestComission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletUserWalletIdEpayRequestComission.info = (userWalletId: number,queryParams?: GetUserWalletUserWalletIdEpayRequestComissionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletUserWalletIdEpayRequestComission.key,userWalletId,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletUserWalletIdEpayRequestComission(
+                   userWalletId,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletUserWalletIdEpayRequestComission.prefetch = (
+            client: QueryClient,
+            userWalletId: number,queryParams?: GetUserWalletUserWalletIdEpayRequestComissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletUserWalletIdEpayRequestComission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetUserWalletUserWalletIdPermittedsubusers = (
+           userWalletId: number,options?:SwaggerTypescriptUseQueryOptions<AccountPermittedSubUserQuery[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletUserWalletIdPermittedsubusers.info( userWalletId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletUserWalletIdPermittedsubusers.info = (userWalletId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletUserWalletIdPermittedsubusers.key,userWalletId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletUserWalletIdPermittedsubusers(
+                   userWalletId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletUserWalletIdPermittedsubusers.prefetch = (
+            client: QueryClient,
+            userWalletId: number,options?:SwaggerTypescriptUseQueryOptions<AccountPermittedSubUserQuery[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletUserWalletIdPermittedsubusers.info( userWalletId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetUserWalletUserWalletIdSettlementRequestComission = (
+           userWalletId: number,queryParams?: GetUserWalletUserWalletIdSettlementRequestComissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletUserWalletIdSettlementRequestComission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletUserWalletIdSettlementRequestComission.info = (userWalletId: number,queryParams?: GetUserWalletUserWalletIdSettlementRequestComissionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletUserWalletIdSettlementRequestComission.key,userWalletId,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletUserWalletIdSettlementRequestComission(
+                   userWalletId,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletUserWalletIdSettlementRequestComission.prefetch = (
+            client: QueryClient,
+            userWalletId: number,queryParams?: GetUserWalletUserWalletIdSettlementRequestComissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletUserWalletIdSettlementRequestComission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetUserWalletUserWalletIdTransferMoneyCommission = (
+           userWalletId: number,queryParams?: GetUserWalletUserWalletIdTransferMoneyCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletUserWalletIdTransferMoneyCommission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletUserWalletIdTransferMoneyCommission.info = (userWalletId: number,queryParams?: GetUserWalletUserWalletIdTransferMoneyCommissionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletUserWalletIdTransferMoneyCommission.key,userWalletId,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletUserWalletIdTransferMoneyCommission(
+                   userWalletId,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletUserWalletIdTransferMoneyCommission.prefetch = (
+            client: QueryClient,
+            userWalletId: number,queryParams?: GetUserWalletUserWalletIdTransferMoneyCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletUserWalletIdTransferMoneyCommission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get user work spaces
+ */
+export const useGetUserWorkspace = (
+           options?:SwaggerTypescriptUseQueryOptions<UserWorkspaceQuery[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWorkspace.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWorkspace.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWorkspace.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserWorkspace(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWorkspace.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<UserWorkspaceQuery[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWorkspace.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Change sub user connection info
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const usePutBusinessUserConnectionConnectionId =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (SubUserConnectionApiModel), {
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,requestBody: EditConnectionInfoInput,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { connectionId,
+          requestBody,
+          
+           configOverride } = _o || {};
+
+            return putBusinessUserConnectionConnectionId(
+                 connectionId,
+          requestBody,
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      export const usePutBusinessUserConnectionConnectionIdPermissionUserWalletId =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions<string, {connectionId: number,
+/**
+ * 
+ * Id of Account to edit it's permissios
+ */
+userWalletId: number,requestBody: EditSubUserPermissionInput,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { connectionId,userWalletId,
+          requestBody,
+          
+           configOverride } = _o || {};
+
+            return putBusinessUserConnectionConnectionIdPermissionUserWalletId(
+                 connectionId,userWalletId,
+          requestBody,
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      
+/**
+ * 
+ * [for Business users only]
+ */
+export const usePutGroupTransferAdd =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (GroupTransferTargetValidationQuery), {requestBody: GroupTransferTargetValidationInput,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { 
+          requestBody,
+          
+           configOverride } = _o || {};
+
+            return putGroupTransferAdd(
+                 
+          requestBody,
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      
+/**
+ * 
+ * Dismiss an Important Action forever.
+ */
+export const usePutNotificationIaNotifIdDismiss =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions<string, {notifId: number,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { notifId,
+          
+          
+           configOverride } = _o || {};
+
+            return putNotificationIaNotifIdDismiss(
+                 notifId,
+          
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      
+/**
+ * 
+ * Update the SubDomain of current Reseller user
+[Feature just allowed for Resellers]
+ */
+export const usePutSubDomain =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (SubDomainApiModel), {requestBody: SubDomainUpdateApiModel,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { 
+          requestBody,
+          
+           configOverride } = _o || {};
+
+            return putSubDomain(
+                 
+          requestBody,
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      
+/**
+ * 
+ * Edit profile [state, city, address]
+[Feature is not allowed for business users]
+[Needs secure login]
+ */
+export const usePutUser =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (UserDetailQuery), {requestBody: UserProfileInput,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { 
+          requestBody,
+          
+           configOverride } = _o || {};
+
+            return putUser(
+                 
+          requestBody,
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      
+/**
+ * 
+ * Edit user bank
+[Needs secure login]
+ */
+export const usePutUserBankUserBankId =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (UserBankApiModel), {
+/**
+ * 
+ * User bank id
+ */
+userBankId: number,requestBody: RequestBodyUserBankInput,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { userBankId,
+          requestBody,
+          
+           configOverride } = _o || {};
+
+            return putUserBankUserBankId(
+                 userBankId,
+          requestBody,
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      
+/**
+ * 
+ * Change user bank show-in-list property
+[Needs secure login]
+ */
+export const usePutUserBankUserBankIdChangeVisibility =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions<string, {userBankId: number,requestBody: UserBankChangeVisibilityInput,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { userBankId,
+          requestBody,
+          
+           configOverride } = _o || {};
+
+            return putUserBankUserBankIdChangeVisibility(
+                 userBankId,
+          requestBody,
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      
+/**
+ * 
+ * Change user avatar
+[Needs secure login]
+ */
+export const usePutUserChangeAvatar =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions<string, {requestBody: UserProfileAvatarInput,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { 
+          requestBody,
+          
+           configOverride } = _o || {};
+
+            return putUserChangeAvatar(
+                 
+          requestBody,
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      export const usePutUserPluginUserPluginIdChangeStatus =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (UserPluginApiModel), {userPluginId: number,requestBody: UserPluginTogggleApiModel,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { userPluginId,
+          requestBody,
+          
+           configOverride } = _o || {};
+
+            return putUserPluginUserPluginIdChangeStatus(
+                 userPluginId,
+          requestBody,
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      export const usePutUserWalletUserWalletId =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (WalletDisplayApiModel), {userWalletId: number,requestBody: RequestBodyAccountCreationApiModel,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { userWalletId,
+          requestBody,
+          
+           configOverride } = _o || {};
+
+            return putUserWalletUserWalletId(
+                 userWalletId,
+          requestBody,
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      export const usePutUserWalletUserWalletIdNotification =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions<string, {userWalletId: number,requestBody: AccountSettingNotificationStatusApiModel,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { userWalletId,
+          requestBody,
+          
+           configOverride } = _o || {};
+
+            return putUserWalletUserWalletIdNotification(
+                 userWalletId,
+          requestBody,
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        "
+`;
+
+exports[`excludes post methods generate type 1`] = `
+"
+//@ts-nocheck
+/**
+* AUTO_GENERATED Do not change this file directly, use config.ts file instead
+*
+* @version 6
+*/
+
+        
+        export interface AccountBalanceApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"realBalance\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"totalBalance\\": number;}
+        
+        
+        export interface AccountCreationApiModel {\\"automaticSettlement\\"?: boolean;\\"getComissionFromPayer\\"?: boolean;\\"isActive\\"?: boolean;\\"title\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"userBankId\\"?: number;}
+        
+        
+        export interface AccountInfoApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"accountOwnerAvatarUrl\\"?: string;\\"accountOwnerTitle\\"?: string;}
+        
+        
+        export interface AccountPermittedSubUserQuery {
+/**
+ * 
+ * - Format: int64
+ */
+\\"connectionId\\": number;\\"connectionStatus\\": SubUserConnectionStatus;
+/**
+ * 
+ * [Deprecated, use 'ConnectionStatus' instead]
+ * @deprecated Use 'ConnectionStatus' instead.
+ */
+\\"subUserConnectionStatus\\":  & (SubUserConnectionStatus);
+/**
+ * 
+ * - Format: guid
+ */
+\\"subuserId\\": string;\\"subuserStatus\\": SubuserStatus;\\"connectDate\\"?: string;\\"connectionStatusDisplay\\"?: string;\\"disconnectDate\\"?: string;\\"subUserAvatarUrl\\"?: string;\\"subUserContact\\"?: string;\\"subUserPositionTitle\\"?: string;\\"subUserTitle\\"?: string;\\"subuserStatusDisplay\\"?: string;}
+        
+        
+        export interface AccountSettingNotificationStatusApiModel {\\"notificationEnabled\\": boolean;}
+        
+        
+        export enum AccountStatus {Block=\\"Block\\",OK=\\"OK\\"}
+        
+        
+        export interface AggregationApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"count\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"sum\\": number;}
+        
+        
+        export interface AllTransactionsReportApiModel {\\"credits\\"?: ReportApiModel[];\\"debits\\"?: ReportApiModel[];}
+        
+        
+        export interface BankApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"id\\": number;\\"logoUrl\\"?: string;\\"name\\"?: string;}
+        
+        
+        export interface BankReceiptApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionAmount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDate\\": string;\\"failed\\": boolean;\\"type\\": EpayRequestType;\\"createDateDisplay\\"?: string;\\"creatorUserAvatarUrl\\"?: string;\\"creatorUserDisplayName\\"?: string;\\"description\\"?: string;\\"failureMessage\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"operationId\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"payerAccountId\\"?: number;\\"payerAccountName\\"?: string;\\"payerAccountNumber\\"?: string;\\"shareUrl\\"?: string;\\"targetAccountNumber\\"?: string;\\"targetAvatarUrl\\"?: string;\\"targetUserDisplayName\\"?: string;\\"typeDisplay\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"voucherId\\"?: number;}
+        
+        
+        export interface BusinessCategoryApiModel {\\"id\\": BusinessType;\\"title\\"?: string;}
+        
+        
+        export enum BusinessShareType {Person=\\"Person\\",PrivateStock=\\"PrivateStock\\",PublicStock=\\"PublicStock\\",Limited=\\"Limited\\",GeneralPartnership=\\"GeneralPartnership\\",Institute=\\"Institute\\",Cooperative=\\"Cooperative\\"}
+        
+        
+        export enum BusinessType {Ads=\\"Ads\\",Investment=\\"Investment\\",Production=\\"Production\\",Trade=\\"Trade\\",Software=\\"Software\\"}
+        
+        
+        export interface BusinessUserConnectionApiModel {
+/**
+ * 
+ * - Format: guid
+ */
+\\"businessId\\": string;\\"status\\": SubUserConnectionStatus;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"subUserConnectionStatus\\":  & (SubUserConnectionStatus);\\"businessAvatarUrl\\"?: string;\\"businessName\\"?: string;\\"connectDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"connectDateTime\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"connectionId\\"?: number;\\"disconnectDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"disconnectDateTime\\"?: string;\\"positionTitle\\"?: string;\\"statusDisplay\\"?: string;}
+        
+        
+        export enum CallbackType {None=\\"None\\",Redirect=\\"Redirect\\",RedirectWithPost=\\"RedirectWithPost\\",Call=\\"Call\\"}
+        
+        
+        export interface ClientPurchaseInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"instituteCode\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"userWalletId\\": number;\\"driverCode\\"?: string;}
+        
+        
+        export enum ComissionType {Percentage=\\"Percentage\\",Fixed=\\"Fixed\\"}
+        
+        
+        export interface CommissionAmountApiModel {
+/**
+ * 
+ * [Deprecated, use 'CommissionAmount' instead]
+ * - Format: decimal
+ * @deprecated Use CommissionAmount instead.
+ */
+\\"comissionAmount\\": number;
+/**
+ * 
+ * کارمزد
+ * - Format: decimal
+ */
+\\"commissionAmount\\": number;
+/**
+ * 
+ * مبلغ اصلی
+ * - Format: decimal
+ */
+\\"requestAmount\\": number;
+/**
+ * 
+ * جمع مبلغ اصلی و کارمزد
+ * - Format: decimal
+ */
+\\"totalAmount\\": number;}
+        
+        
+        export interface CommissionPolicyApiModel {\\"commissionType\\": ComissionType;\\"logicalAction\\": LogicalActionType;\\"commissionTypeDisplay\\"?: string;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"fixedValue\\"?: number;\\"logicalActionDisplay\\"?: string;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"maxValue\\"?: number;
+/**
+ * 
+ * - Format: double
+ */
+\\"percent\\"?: number;\\"title\\"?: string;\\"value\\"?: string;}
+        
+        
+        export interface ContactApiModel {\\"audienceType\\": UserIdentifierType;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"audienceTypeDisplay\\"?: string;\\"contact\\"?: string;\\"fullName\\"?: string;\\"userDisplayName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\"?: string;\\"userProfileImageLink\\"?: string;}
+        
+        
+        export enum DatePart {Minute=\\"Minute\\",Hour=\\"Hour\\",Day=\\"Day\\",Week=\\"Week\\",Month=\\"Month\\",Year=\\"Year\\",All=\\"All\\"}
+        
+        
+        export interface DateReportApiModelOfDecimal {
+/**
+ * 
+ * - Format: int32
+ */
+\\"day\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"key\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"value\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\": number;\\"dayName\\"?: string;\\"label\\"?: string;\\"monthName\\"?: string;}
+        
+        
+        export interface DateReportApiModelOfInteger {
+/**
+ * 
+ * - Format: int32
+ */
+\\"day\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"key\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"value\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\": number;\\"dayName\\"?: string;\\"label\\"?: string;\\"monthName\\"?: string;}
+        
+        
+        export interface DeleteBusinessUserConnectionInvitationIdRemoveQueryParams {
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\"?: number;}
+        
+        
+        export interface DivideEpayRequestServiceInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"expiresAfterDays\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"invoiceDate\\": string;\\"isAutoRedirect\\": boolean;\\"isBlocking\\": boolean;\\"callBackUrl\\"?: string;\\"description\\"?: string;\\"divisions\\"?: DivideEpayRequestShareModel[];\\"invoiceNumber\\"?: string;}
+        
+        
+        export interface DivideEpayRequestShareModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"dividerAmount\\": number;\\"apiKey\\"?: string;\\"invoiceNumber\\"?: string;}
+        
+        
+        export interface DividedEpayRequestCancelInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"dividerAmount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"userAmount\\": number;\\"description\\"?: string;\\"firstName\\"?: string;\\"invoiceNumber\\"?: string;\\"lastName\\"?: string;\\"paymentToken\\"?: string;\\"shebaNo\\"?: string;\\"userApiKey\\"?: string;}
+        
+        
+        export interface DividedEpayRequestCancelResult {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"cancelledAmount\\": number;}
+        
+        
+        export interface DividedEpayRequestUnblockInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"dividerAmount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"userAmount\\": number;\\"description\\"?: string;\\"invoiceNumber\\"?: string;\\"paymentToken\\"?: string;\\"userApiKey\\"?: string;}
+        
+        
+        export interface DividedEpayRequestUnblockResult {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"unblockedAmount\\": number;}
+        
+        
+        export interface DocumentApiModel {\\"contentType\\": DocumentContentType;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDate\\": string;
+/**
+ * 
+ * [Deprecated, use 'ContentType' instead]
+ * @deprecated Use 'ContentType' instead.
+ */
+\\"documentContentType\\":  & (DocumentContentType);
+/**
+ * 
+ * - Format: int64
+ */
+\\"fileSize\\": number;\\"fileType\\": FileTypes;
+/**
+ * 
+ * [Deprecated, use 'FileType' instead]
+ * @deprecated Use 'FileType' instead.
+ */
+\\"fileTypes\\":  & (FileTypes);
+/**
+ * 
+ * - Format: guid
+ */
+\\"uniqueId\\": string;\\"contentTypeDisplay\\"?: string;\\"fileName\\"?: string;\\"fileTypeDisplay\\"?: string;\\"fileUrl\\"?: string;}
+        
+        
+        export enum DocumentContentType {Other=\\"Other\\",UserBankVerification=\\"UserBankVerification\\",IdentityCard=\\"IdentityCard\\",BusinessStatute=\\"BusinessStatute\\",BusinessLatestChangesAnnouncement=\\"BusinessLatestChangesAnnouncement\\",BusinessOwnersIdentityCards=\\"BusinessOwnersIdentityCards\\",BusinessOwnersBirthCertificates=\\"BusinessOwnersBirthCertificates\\"}
+        
+        
+        export interface DocumentInput {\\"documentContentType\\": DocumentContentType;
+/**
+ * 
+ * - Format: guid
+ */
+\\"fileUniqueId\\": string;}
+        
+        
+        export interface DriverInfoResult {\\"barcodType\\": number;\\"barcodTypeDescription\\"?: string;\\"customData\\"?:  & (TaxiInfoOutput);\\"firstName\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"identificationCode\\"?: number;\\"identificationDesc\\"?: string;\\"imageUrl\\"?: string;\\"lastName\\"?: string;\\"nationalCode\\"?: string;\\"price\\"?: TaxiPriceOutput[];}
+        
+        
+        export interface DropDownResultItemOfIdentityStatus {\\"value\\": IdentityStatus;\\"display\\"?: string;}
+        
+        
+        export interface DropDownResultOfIdentityStatus {\\"items\\"?: DropDownResultItemOfIdentityStatus[];}
+        
+        
+        export interface EPayPluginSpecificApiModel {\\"id\\"?: string;\\"persianName\\"?: string;
+/**
+ * 
+ * [Deprecated, don't use this property anymore, it is always null]
+ * @deprecated Don't use this property anymore, it is always null.
+ */
+\\"pluginPropertyId\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'Id' instead]
+ * @deprecated Use 'Id' instead.
+ */
+\\"pluginPropertyName\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'PersianName' instead]
+ * @deprecated Use 'PersianName' instead.
+ */
+\\"pluginPropertyPersianName\\"?: string;\\"value\\"?: string;}
+        
+        
+        export interface EPayRequestAudienceInput {\\"contact\\"?: string;\\"fullName\\"?: string;}
+        
+        
+        export interface EditConnectionInfoInput {\\"position\\"?: string;}
+        
+        
+        export interface EditSubUserPermissionInput {\\"isEnabled\\"?: boolean;\\"subUserPermissionType\\"?:  & (SubUserPermissionType);}
+        
+        
+        export enum EpayRequestActualState {Initiated=\\"Initiated\\",Paid=\\"Paid\\",Cancelled=\\"Cancelled\\",Expired=\\"Expired\\"}
+        
+        
+        export interface EpayRequestApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"epayRequestStatus\\":  & (EpayRequestStatus);
+/**
+ * 
+ * - Format: date-time
+ */
+\\"expireDateTime\\": string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"status\\": EpayRequestActualState;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"assistantDisplayName\\"?: string;\\"assistantPositionTitle\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"assistantUserId\\"?: string;\\"createDate\\"?: string;\\"description\\"?: string;
+/**
+ * 
+ * [Deprecated, don't use EpayRequestAudience]
+ * @deprecated Don't use EpayRequestAudience.
+ */
+\\"epayRequestAudience\\"?: EPayRequestAudienceInput[];\\"expireDate\\"?: string;\\"payDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"payDateTime\\"?: string;\\"payerName\\"?: string;\\"paymentLink\\"?: string;\\"qrCodeLink\\"?: string;\\"statusDisplay\\"?: string;\\"targetDisplayName\\"?: string;\\"userAccountName\\"?: string;}
+        
+        
+        export interface EpayRequestCheckStatusResult {\\"requestStatus\\": EpayRequestStatus;\\"bankReferenceId\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"verifyDate\\"?: string;}
+        
+        
+        export interface EpayRequestDetailApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * [Deprecated, use 'CommissionAmount' instead]
+ * - Format: decimal
+ * @deprecated Use 'CommissionAmount' instead.
+ */
+\\"comissionAmount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionAmount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"epayRequestStatus\\":  & (EpayRequestStatus);
+/**
+ * 
+ * - Format: date-time
+ */
+\\"expireDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'GetCommissionFromPayer' instead]
+ * @deprecated Use 'GetCommissionFromPayer' instead.
+ */
+\\"getComissionByPayer\\": boolean;\\"getCommissionFromPayer\\": boolean;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"status\\": EpayRequestActualState;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"assistantDisplayName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"assistantUserId\\"?: string;\\"audiences\\"?: ContactApiModel[];\\"description\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'Audiences' instead]
+ * @deprecated Use 'Audiences' instead.
+ */
+\\"epayRequestAudience\\"?: ContactApiModel[];
+/**
+ * 
+ * [Deprecated, use 'PluginProperties' instead]
+ * @deprecated Use 'PluginProperties' instead.
+ */
+\\"epayRequestPluginSpecific\\"?: EPayPluginSpecificApiModel[];
+/**
+ * 
+ * - Format: date-time
+ */
+\\"payDateTime\\"?: string;\\"paymentLink\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"pluginId\\"?: number;\\"pluginName\\"?: string;\\"pluginProperties\\"?: EPayPluginSpecificApiModel[];\\"publicLink\\"?: string;\\"qrCodeLink\\"?: string;\\"statusDisplay\\"?: string;\\"token\\"?: string;\\"userAccountName\\"?: string;}
+        
+        
+        export interface EpayRequestForUserQuery {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * [Deprecated, don't use this property anymore]
+ * @deprecated Don't use this property anymore.
+ */
+\\"canBeCanceled\\": boolean;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"epayRequestStatus\\":  & (EpayRequestStatus);
+/**
+ * 
+ * - Format: date-time
+ */
+\\"expireDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'Token' for EPays that created by others]
+ * - Format: int64
+ * @deprecated Use 'Token' for EPays that created by others.
+ */
+\\"id\\": number;\\"status\\": EpayRequestActualState;
+/**
+ * 
+ * [Deprecated, use 'UserDisplayName' instead]
+ * @deprecated Use 'UserDisplayName' instead.
+ */
+\\"applicantName\\"?: string;\\"createDate\\"?: string;\\"description\\"?: string;\\"expireDate\\"?: string;\\"paymentUrl\\"?: string;\\"statusDisplay\\"?: string;\\"token\\"?: string;\\"userAccountNumber\\"?: string;\\"userDisplayName\\"?: string;}
+        
+        
+        export interface EpayRequestPayInput {\\"description\\"?: string;}
+        
+        
+        export interface EpayRequestPluginSpecificInput {\\"pluginPropertyId\\"?: string;\\"value\\"?: string;}
+        
+        
+        export interface EpayRequestPublicInfoApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"expireDate\\": string;\\"status\\": EpayRequestStatus;\\"description\\"?: string;\\"expireDateDisplay\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"payDate\\"?: string;\\"payDateDisplay\\"?: string;\\"payerName\\"?: string;\\"paymentUrl\\"?: string;\\"statusDisplay\\"?: string;\\"token\\"?: string;\\"userAccountNumber\\"?: string;\\"userAvatarUrl\\"?: string;\\"userDisplayName\\"?: string;}
+        
+        
+        export interface EpayRequestServiceInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"callbackType\\": CallbackType;
+/**
+ * 
+ * - Format: guid
+ */
+\\"clientId\\": string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"domainId\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"expiresAfterDays\\": number;\\"getComissionFromPayer\\": boolean;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"invoiceDate\\": string;\\"isAutoConfirm\\": boolean;\\"isAutoRedirect\\": boolean;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userAccountId\\": number;
+/**
+ * 
+ * - Format: guid
+ * - minLength: 1
+ */
+\\"userId\\": string;\\"audiences\\"?: EPayRequestAudienceInput[];\\"callbackUrl\\"?: string;\\"description\\"?: string;\\"invoiceNumber\\"?: string;}
+        
+        
+        export enum EpayRequestStatus {Initiated=\\"Initiated\\",Paid=\\"Paid\\",Cancelled=\\"Cancelled\\",Expired=\\"Expired\\",Viewed=\\"Viewed\\"}
+        
+        
+        export interface EpayRequestTaskInput {\\"epayRequestTaskType\\": EpayRequestTaskType;}
+        
+        
+        export enum EpayRequestTaskType {Resend=\\"Resend\\",Cancel=\\"Cancel\\"}
+        
+        
+        export enum EpayRequestType {Link=\\"Link\\",POS=\\"POS\\",Divide=\\"Divide\\",DivideWithBlock=\\"DivideWithBlock\\",Charge=\\"Charge\\",IPG=\\"IPG\\"}
+        
+        
+        export interface EpayRequestWcfResult {\\"paymentUrl\\"?: string;\\"requestToken\\"?: string;}
+        
+        
+        export enum FieldDisplayType {String=\\"String\\",Text=\\"Text\\",Currency=\\"Currency\\",Integer=\\"Integer\\",Float=\\"Float\\",Boolean=\\"Boolean\\",List=\\"List\\"}
+        
+        
+        export interface FileApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"fileSize\\": number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"uniqueId\\": string;\\"fileName\\"?: string;\\"fileUrl\\"?: string;}
+        
+        
+        export enum FileTypes {Other=\\"Other\\",Image=\\"Image\\",Pdf=\\"Pdf\\"}
+        
+        
+        export interface ForgetPasswordQuery {\\"token\\"?: string;}
+        
+        
+        export interface FullRegisterApiModel {\\"fullName\\"?: string;\\"introducerCode\\"?: string;\\"phoneNumber\\"?: string;}
+        
+        
+        export enum Gender {Unknown=\\"Unknown\\",Male=\\"Male\\",Female=\\"Female\\"}
+        
+        
+        export interface GetBusinessUserConnectionActiveQueryParams {
+/**
+ * 
+ * defaults to 0
+ * - Format: int32
+ */
+\\"skip\\"?: number;
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;}
+        
+        
+        export interface GetBusinessUserConnectionConnectionIdEpayQueryParams {
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endDate\\"?: string;\\"epayRequestStatus\\"?: \\"Initiated\\" | \\"Paid\\" | \\"Cancelled\\" | \\"Expired\\" | \\"Viewed\\";
+/**
+ * 
+ * - Format: int32
+ */
+\\"pluginId\\"?: number;\\"plugin_SepidarCustomerName\\"?: string;\\"plugin_SepidarCustomerNumber\\"?: string;\\"plugin_SepidarDocumentNumber\\"?: string;\\"plugin_SepidarVoucherType\\"?: string;\\"plugin_ZhenicCustomerName\\"?: string;\\"plugin_ZhenicCustomerNumber\\"?: string;\\"plugin_ZhenicDollarAmount\\"?: string;\\"plugin_ZhenicDollarAmountRate\\"?: string;\\"plugin_ZhenicEuroAmount\\"?: string;\\"plugin_ZhenicEuroAmountRate\\"?: string;\\"plugin_ZhenicInvoiceNumber\\"?: string;\\"plugin_ZhenicRialAmount\\"?: string;
+/**
+ * 
+ * defaults to 0
+ * - Format: int32
+ */
+\\"skip\\"?: number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startDate\\"?: string;
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface GetBusinessUserConnectionQueryParams {
+/**
+ * 
+ * defaults to 0
+ * - Format: int32
+ */
+\\"skip\\"?: number;\\"states\\"?:  & (SubUserConnectionStatus)[];\\"subUserConnectionStatus\\"?: \\"Pending\\" | \\"Rejected\\" | \\"Connected\\" | \\"Disconnected\\" | \\"Deleted\\";
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;}
+        
+        
+        export interface GetEpayRequestCountQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Year\\"?: number;}
+        
+        
+        export interface GetEpayRequestExcelQueryParams {\\"accountIds\\"?: number[];
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endDate\\"?: string;\\"epayRequestStatus\\"?: \\"Initiated\\" | \\"Paid\\" | \\"Cancelled\\" | \\"Expired\\" | \\"Viewed\\";
+/**
+ * 
+ * - Format: int32
+ */
+\\"pluginId\\"?: number;\\"plugin_SepidarCustomerName\\"?: string;\\"plugin_SepidarCustomerNumber\\"?: string;\\"plugin_SepidarDocumentNumber\\"?: string;\\"plugin_SepidarVoucherType\\"?: string;\\"plugin_ZhenicCustomerName\\"?: string;\\"plugin_ZhenicCustomerNumber\\"?: string;\\"plugin_ZhenicDollarAmount\\"?: string;\\"plugin_ZhenicDollarAmountRate\\"?: string;\\"plugin_ZhenicEuroAmount\\"?: string;\\"plugin_ZhenicEuroAmountRate\\"?: string;\\"plugin_ZhenicInvoiceNumber\\"?: string;\\"plugin_ZhenicRialAmount\\"?: string;
+/**
+ * 
+ * defaults to 0
+ * - Format: int32
+ */
+\\"skip\\"?: number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startDate\\"?: string;\\"states\\"?:  & (EpayRequestActualState)[];
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface GetEpayRequestForMeCountQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Year\\"?: number;}
+        
+        
+        export interface GetEpayRequestForMeQueryParams {\\"applicantName\\"?: string;\\"applicantPhoneNumber\\"?: string;\\"endDate\\"?: string;
+/**
+ * 
+ * obsoleted
+ */
+\\"epayRequestStatus\\"?: \\"Initiated\\" | \\"Paid\\" | \\"Cancelled\\" | \\"Expired\\" | \\"Viewed\\";
+/**
+ * 
+ * defaults to 0
+ * - Format: int32
+ */
+\\"skip\\"?: number;\\"startDate\\"?: string;\\"states\\"?:  & (EpayRequestActualState)[];
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;}
+        
+        
+        export interface GetEpayRequestForMeReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Year\\"?: number;}
+        
+        
+        export interface GetEpayRequestPosQrAccountNumberQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"subUserConId\\"?: number;}
+        
+        
+        export interface GetEpayRequestQueryParams {\\"accountIds\\"?: number[];
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endDate\\"?: string;\\"epayRequestStatus\\"?: \\"Initiated\\" | \\"Paid\\" | \\"Cancelled\\" | \\"Expired\\" | \\"Viewed\\";
+/**
+ * 
+ * - Format: int32
+ */
+\\"pluginId\\"?: number;\\"plugin_SepidarCustomerName\\"?: string;\\"plugin_SepidarCustomerNumber\\"?: string;\\"plugin_SepidarDocumentNumber\\"?: string;\\"plugin_SepidarVoucherType\\"?: string;\\"plugin_ZhenicCustomerName\\"?: string;\\"plugin_ZhenicCustomerNumber\\"?: string;\\"plugin_ZhenicDollarAmount\\"?: string;\\"plugin_ZhenicDollarAmountRate\\"?: string;\\"plugin_ZhenicEuroAmount\\"?: string;\\"plugin_ZhenicEuroAmountRate\\"?: string;\\"plugin_ZhenicInvoiceNumber\\"?: string;\\"plugin_ZhenicRialAmount\\"?: string;
+/**
+ * 
+ * defaults to 0
+ * - Format: int32
+ */
+\\"skip\\"?: number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startDate\\"?: string;\\"states\\"?:  & (EpayRequestActualState)[];
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface GetEpayRequestReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Year\\"?: number;}
+        
+        
+        export interface GetEpayRequestUserWalletIdCommissionQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;}
+        
+        
+        export interface GetGroupTransferCommissionQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface GetIntegrationQueryParams {
+/**
+ * 
+ * code of the corresponding institude
+ * - Format: int32
+ */
+\\"instituteCode\\"?: number;
+/**
+ * 
+ * code specific to each driver
+ */
+\\"termainalId\\"?: string;}
+        
+        
+        export interface GetKpiCurrentQueryParams {\\"datePart\\"?: DatePart[];\\"kpiName\\"?: string[];}
+        
+        
+        export interface GetKpiLastQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"count\\"?: number;\\"datePart\\"?: DatePart[];\\"endPartial\\"?: boolean;\\"kpiName\\"?: string[];}
+        
+        
+        export interface GetKpiQueryParams {\\"datePart\\"?: DatePart[];
+/**
+ * 
+ * - Format: date-time
+ */
+\\"end\\"?: string;\\"endPartial\\"?: boolean;\\"kpiName\\"?: string[];
+/**
+ * 
+ * - Format: date-time
+ */
+\\"start\\"?: string;\\"startPartial\\"?: boolean;}
+        
+        
+        export interface GetNotificationUnreadQueryParams {\\"channels\\"?: NotificationChannel[];}
+        
+        
+        export interface GetPosAccountNumberQueryParams {
+/**
+ * 
+ * Subuser Connection Id
+ * - Format: int64
+ */
+\\"subUserConId\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardCommissionReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardCommissionSumQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardIntroducedCountQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardIntroducedReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardLinksCountQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardLinksPaidCountQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardLinksPaidReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardLinksReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardTransactionsCountQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardTransactionsReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserIntroducedQueryParams {\\"identityStatuses\\"?: IdentityStatus[];\\"isActive\\"?: boolean;\\"isPerson\\"?: boolean;
+/**
+ * 
+ * YYYY-MM-DD
+ * - Format: date-time
+ */
+\\"lastActivityFrom\\"?: string;
+/**
+ * 
+ * YYYY-MM-DD
+ * - Format: date-time
+ */
+\\"lastActivityTo\\"?: string;\\"orderBy\\"?: string;\\"orderDesc\\"?: boolean;
+/**
+ * 
+ * YYYY-MM-DD
+ * - Format: date-time
+ */
+\\"registeredFrom\\"?: string;
+/**
+ * 
+ * YYYY-MM-DD
+ * - Format: date-time
+ */
+\\"registeredTo\\"?: string;\\"searchInput\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"skip\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"take\\"?: number;}
+        
+        
+        export interface GetTransactionExcelQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amountFrom\\"?: number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amountTo\\"?: number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endDate\\"?: string;\\"logicalActions\\"?:  & (LogicalActionType)[];\\"operationType\\"?: \\"Unknown\\" | \\"Normal\\" | \\"System\\" | \\"DomainCommission\\" | \\"ResellerCommission\\" | \\"Block\\" | \\"Unblock\\" | \\"Refund\\" | \\"NoCommissionRemainGift\\" | \\"RemainGift\\" | \\"DomainBankBatchTransfer\\" | \\"SettlementBatchTransferItem\\" | \\"Synchronization\\" | \\"BlockchainWithdrawInternalTransfer\\" | \\"BlockchainWithdrawUserWallet\\" | \\"BlockchainIncomingTransaction\\" | \\"BlockchainWithdrawUserWalletOffchain\\" | \\"BlockchainFee\\";\\"operationTypes\\"?:  & (TransactionOperationType)[];
+/**
+ * 
+ * - Format: int32
+ */
+\\"skip\\"?: number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startDate\\"?: string;
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;\\"transactionType\\"?: \\"Debt\\" | \\"Credit\\";\\"transactionTypes\\"?:  & (TransactionType)[];
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;\\"voucherTypes\\"?:  & (VoucherOperationType)[];}
+        
+        
+        export interface GetTransactionQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amountFrom\\"?: number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amountTo\\"?: number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endDate\\"?: string;
+/**
+ * 
+ * deprecated. use 'take' instead.
+ * - Format: int32
+ */
+\\"limit\\"?: number;\\"logicalActions\\"?:  & (LogicalActionType)[];\\"operationType\\"?: \\"Unknown\\" | \\"Normal\\" | \\"System\\" | \\"DomainCommission\\" | \\"ResellerCommission\\" | \\"Block\\" | \\"Unblock\\" | \\"Refund\\" | \\"NoCommissionRemainGift\\" | \\"RemainGift\\" | \\"DomainBankBatchTransfer\\" | \\"SettlementBatchTransferItem\\" | \\"Synchronization\\" | \\"BlockchainWithdrawInternalTransfer\\" | \\"BlockchainWithdrawUserWallet\\" | \\"BlockchainIncomingTransaction\\" | \\"BlockchainWithdrawUserWalletOffchain\\" | \\"BlockchainFee\\";\\"operationTypes\\"?:  & (TransactionOperationType)[];
+/**
+ * 
+ * - Format: int32
+ */
+\\"skip\\"?: number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startDate\\"?: string;
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;\\"transactionType\\"?: \\"Debt\\" | \\"Credit\\";\\"transactionTypes\\"?:  & (TransactionType)[];
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;\\"voucherTypes\\"?:  & (VoucherOperationType)[];}
+        
+        
+        export interface GetTransactionReportAllQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Year\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"accountId\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"businessCategoryId\\"?: number;\\"operationType\\"?: \\"Unknown\\" | \\"Normal\\" | \\"System\\" | \\"DomainCommission\\" | \\"ResellerCommission\\" | \\"Block\\" | \\"Unblock\\" | \\"Refund\\" | \\"NoCommissionRemainGift\\" | \\"RemainGift\\" | \\"DomainBankBatchTransfer\\" | \\"SettlementBatchTransferItem\\" | \\"Synchronization\\" | \\"BlockchainWithdrawInternalTransfer\\" | \\"BlockchainWithdrawUserWallet\\" | \\"BlockchainIncomingTransaction\\" | \\"BlockchainWithdrawUserWalletOffchain\\" | \\"BlockchainFee\\";\\"type\\"?: \\"Debt\\" | \\"Credit\\";}
+        
+        
+        export interface GetTransactionReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Year\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"accountId\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"businessCategoryId\\"?: number;\\"operationType\\"?: \\"Unknown\\" | \\"Normal\\" | \\"System\\" | \\"DomainCommission\\" | \\"ResellerCommission\\" | \\"Block\\" | \\"Unblock\\" | \\"Refund\\" | \\"NoCommissionRemainGift\\" | \\"RemainGift\\" | \\"DomainBankBatchTransfer\\" | \\"SettlementBatchTransferItem\\" | \\"Synchronization\\" | \\"BlockchainWithdrawInternalTransfer\\" | \\"BlockchainWithdrawUserWallet\\" | \\"BlockchainIncomingTransaction\\" | \\"BlockchainWithdrawUserWalletOffchain\\" | \\"BlockchainFee\\";\\"type\\"?: \\"Debt\\" | \\"Credit\\";}
+        
+        
+        export interface GetTransferRecentQueryParams {
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;}
+        
+        
+        export interface GetTransferSearchQueryParams {\\"accountNumber\\"?: string;
+/**
+ * 
+ * Phone number or email address
+ */
+\\"contact\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"customerNumber\\"?: number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface GetTransferUserWalletIdCommissionQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;}
+        
+        
+        export interface GetUserWalletAccountNumberQrcodeQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"subUserConId\\"?: number;}
+        
+        
+        export interface GetUserWalletSearchQueryParams {\\"accountNumber\\"?: string;\\"contact\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"customerNumber\\"?: number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface GetUserWalletUserWalletIdEpayRequestComissionQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;}
+        
+        
+        export interface GetUserWalletUserWalletIdSettlementRequestComissionQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;}
+        
+        
+        export interface GetUserWalletUserWalletIdTransferMoneyCommissionQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;}
+        
+        
+        export interface GroupTransferInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"totalAmount\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"description\\"?: string;\\"targets\\"?: GroupTransferTargetInput[];}
+        
+        
+        export interface GroupTransferQuery {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDate\\": string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"voucherId\\": number;\\"createDateDisplay\\"?: string;\\"description\\"?: string;\\"targets\\"?: GroupTransferTargetQuery[];\\"userAccountName\\"?: string;\\"userDisplayName\\"?: string;}
+        
+        
+        export interface GroupTransferTargetInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"description\\"?: string;\\"identifier\\"?: string;}
+        
+        
+        export interface GroupTransferTargetQuery {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"accountName\\"?: string;\\"description\\"?: string;\\"userDisplayName\\"?: string;\\"userPhoneNumber\\"?: string;}
+        
+        
+        export enum GroupTransferTargetStatus {InvalidIdentifier=\\"InvalidIdentifier\\",Ok=\\"Ok\\",Unregistered=\\"Unregistered\\",BlockedAccount=\\"BlockedAccount\\",InvalidAmount=\\"InvalidAmount\\"}
+        
+        
+        export interface GroupTransferTargetValidationInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"description\\"?: string;
+/**
+ * 
+ * PhoneNumber or Account Number
+ */
+\\"identifier\\"?: string;}
+        
+        
+        export interface GroupTransferTargetValidationQuery {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"identifierType\\": UserIdentifierType;\\"status\\": GroupTransferTargetStatus;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userCustomerNumber\\": number;\\"accountNumber\\"?: string;\\"identifier\\"?: string;\\"identifierTypeDisplay\\"?: string;\\"name\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'StatusDisplay' instead]
+ * @deprecated Use 'StatusDisplay' instead.
+ */
+\\"statusDescription\\"?: string;\\"statusDisplay\\"?: string;\\"userDisplayName\\"?: string;\\"userPhoneNumber\\"?: string;}
+        
+        
+        export enum IPGStatus {NotRequested=\\"NotRequested\\"}
+        
+        
+        export enum IdentityStatus {None=\\"None\\",WatingForCheck=\\"WatingForCheck\\",Checking=\\"Checking\\",EditingRequired=\\"EditingRequired\\",Approved=\\"Approved\\",Rejected=\\"Rejected\\"}
+        
+        
+        export interface ImportantActionApiModel {\\"closeable\\": boolean;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createTime\\": string;\\"dismissible\\": boolean;
+/**
+ * 
+ * - Format: int32
+ */
+\\"id\\": number;\\"isSeen\\": boolean;\\"level\\": NotificationLevel;\\"type\\": NotificationModelType;\\"data\\"?: string;\\"dataId\\"?: string;\\"levelDisplay\\"?: string;\\"text\\"?: string;\\"title\\"?: string;\\"typeDisplay\\"?: string;}
+        
+        
+        export interface InitApiModel {\\"versionState\\": TerminalVersionState;\\"appDownloadLink\\"?: string;\\"versionStateDisplay\\"?: string;}
+        
+        
+        export interface KpiResult {
+/**
+ * 
+ * - Format: date-time
+ */
+\\"end\\": string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"start\\": string;\\"datePart\\"?:  & (DatePart);\\"kpiName\\"?: string;\\"targetIds\\"?: string[];\\"values\\"?: KpiResultValue[];}
+        
+        
+        export interface KpiResultValue {
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endPoint\\": string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"extractedTime\\": string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startPoint\\": string;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"value\\": number;\\"targetId\\"?: string;}
+        
+        
+        export enum LogEventLevel {Verbose=\\"Verbose\\",Debug=\\"Debug\\",Information=\\"Information\\",Warning=\\"Warning\\",Error=\\"Error\\",Fatal=\\"Fatal\\"}
+        
+        
+        export interface LogSetting {\\"globalLogLevel\\": LogEventLevel;\\"septaPayLogLevel\\": LogEventLevel;\\"serilogLogLevel\\": LogEventLevel;}
+        
+        
+        export enum LogicalActionType {EpayRequest=\\"EpayRequest\\",TransferMoney=\\"TransferMoney\\",AccountChargeRequest=\\"AccountChargeRequest\\",ServiceBill=\\"ServiceBill\\",ServiceMobileCharge=\\"ServiceMobileCharge\\",POS=\\"POS\\",ShareAndBlockRequest=\\"ShareAndBlockRequest\\",ShareRequest=\\"ShareRequest\\",Settlement=\\"Settlement\\",GroupTransferMoney=\\"GroupTransferMoney\\",ShareAndUnblock=\\"ShareAndUnblock\\",Refund=\\"Refund\\",PayCommand=\\"PayCommand\\",Gift=\\"Gift\\",TaxiFairPayment=\\"TaxiFairPayment\\",HitoBitFee=\\"HitoBitFee\\"}
+        
+        
+        export interface MachineSignUp {
+/**
+ * 
+ * - Format: int64
+ */
+\\"customerNumber\\": number;\\"apiKey\\"?: string;}
+        
+        
+        export interface NewChargeRequestInput {
+/**
+ * 
+ * مبلغ شارژ
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * آدرس بازگشت بعد از پرداخت
+ */
+\\"callbackUrl\\"?: string;}
+        
+        
+        export interface NewChargeRequestResultQuery {\\"paymentLink\\"?: string;}
+        
+        
+        export interface NewEpayRequestInput {
+/**
+ * 
+ * مبلغ شارژ
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * نوع ارجاع در هنگام ایجاد درخواست
+ */
+\\"callbackType\\":  & (CallbackType);
+/**
+ * 
+ * تاریخ انتقضا لینک ایجاد شده
+ * - Format: int32
+ */
+\\"expireDays\\": number;
+/**
+ * 
+ * انتقال مستقیم به درگاه
+ 
+ */
+\\"isAutoConfirm\\": boolean;
+/**
+ * 
+ * - Format: guid
+ */
+\\"assisstantUserId\\"?: string;
+/**
+ * 
+ * اطلاعات پرداخت کننده / ها
+ */
+\\"audiences\\"?: EPayRequestAudienceInput[];
+/**
+ * 
+ * آدرس بازگشت بعد از پرداخت
+ */
+\\"callbackUrl\\"?: string;
+/**
+ * 
+ * توضحیات درخواست (بابت)
+ */
+\\"description\\"?: string;
+/**
+ * 
+ * نحوه دریافت کارمزد
+ */
+\\"getComissionByPayer\\"?: boolean;
+/**
+ * 
+ * تاریخ فاکتور
+ * - Format: date-time
+ */
+\\"invoiceDate\\"?: string;
+/**
+ * 
+ * شماره فاکتور
+ */
+\\"invoiceNumber\\"?: string;
+/**
+ * 
+ * ...
+ * - Format: int32
+ */
+\\"pluginId\\"?: number;
+/**
+ * 
+ * ...
+ */
+\\"pluginSpecifics\\"?: EpayRequestPluginSpecificInput[];}
+        
+        
+        export interface NewUserIdentityRequestInput {\\"documents\\"?: DocumentInput[];\\"firstName\\"?: string;\\"lastName\\"?: string;\\"nationalCode\\"?: string;}
+        
+        
+        export interface NotificationApiModel {
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createTime\\": string;\\"isSeen\\": boolean;\\"level\\": NotificationLevel;\\"type\\": NotificationModelType;\\"dataId\\"?: string;\\"levelDisplay\\"?: string;\\"text\\"?: string;\\"title\\"?: string;\\"typeDisplay\\"?: string;}
+        
+        
+        export enum NotificationChannel {Notification=\\"Notification\\",ImportantAction=\\"ImportantAction\\",SMS=\\"SMS\\",Email=\\"Email\\",FCM=\\"FCM\\",SignalR=\\"SignalR\\"}
+        
+        
+        export enum NotificationLevel {Unknown=\\"Unknown\\",Default=\\"Default\\",Success=\\"Success\\",Info=\\"Info\\",Warning=\\"Warning\\",Danger=\\"Danger\\"}
+        
+        
+        export enum NotificationModelType {Default=\\"Default\\",EPayRequestUnpaid=\\"EPayRequestUnpaid\\",EPayRequestPaid=\\"EPayRequestPaid\\",UserIdentityUnknown=\\"UserIdentityUnknown\\",UserIdentityApproved=\\"UserIdentityApproved\\",UserIdentityRejected=\\"UserIdentityRejected\\",UpgradeToBusinessApproved=\\"UpgradeToBusinessApproved\\",UpgradeToBusinessRejected=\\"UpgradeToBusinessRejected\\",UserBankApproved=\\"UserBankApproved\\",UserBankRejected=\\"UserBankRejected\\",SubUserConnectionCreated=\\"SubUserConnectionCreated\\",SubUserInvitationRejected=\\"SubUserInvitationRejected\\",SubUserInvitationSent=\\"SubUserInvitationSent\\",MoneyDeposit=\\"MoneyDeposit\\",MoneyWithdrawal=\\"MoneyWithdrawal\\",SubUserDisconnectedByBusiness=\\"SubUserDisconnectedByBusiness\\",SubUserDisconnectedBySubUser=\\"SubUserDisconnectedBySubUser\\",Activities=\\"Activities\\",TradeNotification=\\"TradeNotification\\",HitoBitNews=\\"HitoBitNews\\",SystemMessages=\\"SystemMessages\\"}
+        
+        
+        export enum PlatformType {Unknown=\\"Unknown\\",Server=\\"Server\\",Android=\\"Android\\",iOS=\\"iOS\\",Device=\\"Device\\",Browser=\\"Browser\\",PWA=\\"PWA\\",Web=\\"Web\\",Windows=\\"Windows\\",Linux=\\"Linux\\",macOS=\\"macOS\\",Desktop=\\"Desktop\\"}
+        
+        
+        export interface PluginApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"id\\": number;\\"amountCalculationExpression\\"?: string;\\"logoFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"logoFileUniqueId\\"?: string;\\"logoFileUrl\\"?: string;\\"name\\"?: string;\\"properties\\"?: PluginPropertyApiModel[];}
+        
+        
+        export interface PluginPropertyApiModel {\\"fieldType\\": FieldDisplayType;\\"isFilterable\\": boolean;\\"isRequired\\": boolean;\\"currencyName\\"?: string;\\"description\\"?: string;\\"name\\"?: string;\\"title\\"?: string;\\"value\\"?: string;}
+        
+        
+        export interface PosLandingPageApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"domainId\\": number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"accountNumber\\"?: string;\\"domainEnglishName\\"?: string;\\"domainLogoFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"domainLogoFileUniqueId\\"?: string;\\"domainLogoFileUrl\\"?: string;\\"domainPersianName\\"?: string;\\"getCommissionFromPayer\\"?: boolean;\\"subUserAvatarFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"subUserAvatarFileUniqueId\\"?: string;\\"subUserAvatarFileUrl\\"?: string;\\"subUserDisplayName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"subUserId\\"?: string;\\"userAvatarFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userAvatarFileUniqueId\\"?: string;\\"userAvatarFileUrl\\"?: string;\\"userDisplayName\\"?: string;}
+        
+        
+        export interface PosOnlinePayInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"callBackUrl\\"?: string;\\"callbackType\\"?:  & (CallbackType);\\"description\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"subuserId\\"?: string;}
+        
+        
+        export interface PosWalletPayInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"description\\"?: string;}
+        
+        
+        export interface RegisterApiModel {\\"deviceBrandName\\"?: string;\\"deviceId\\"?: string;\\"deviceOsVersion\\"?: string;\\"deviceToken\\"?: string;\\"phoneNumber\\"?: string;}
+        
+        
+        export interface RegisterNewUserQuery {
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"token\\"?: string;}
+        
+        
+        export interface ReportApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"count\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"day\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"dayOfWeek\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"key\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"sum\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\": number;\\"dayName\\"?: string;\\"label\\"?: string;\\"monthName\\"?: string;
+/**
+ * 
+ * سال دو رقمی
+ */
+\\"yearShort\\"?: string;}
+        
+        
+        export type RequestBodyAccountCreationApiModel = AccountCreationApiModel
+        
+        
+        export interface RequestBodyFile_Upload {
+/**
+ * 
+ * - Format: binary
+ */
+\\"file\\"?: string;}
+        
+        
+        export type RequestBodyLogEventLevel = LogEventLevel
+        
+        
+        export type RequestBodyNewEpayRequestInput = NewEpayRequestInput
+        
+        
+        export type RequestBodySubUserNotificationStatusInput = SubUserNotificationStatusInput
+        
+        
+        export type RequestBodyTransferMoneyInput = TransferMoneyInput
+        
+        
+        export type RequestBodyUserBankInput = UserBankInput
+        
+        
+        export interface RequestTotpInput {\\"phoneNumber\\"?: string;}
+        
+        
+        export interface ReselledUserActivityApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"commissionsPaidToResellerCount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionsPaidToResellerSum\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"generatedLinks\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"paidGeneratedLinks\\": number;}
+        
+        
+        export interface ReselledUserApiModel {\\"identityStatus\\": IdentityStatus;\\"ipgStatus\\": IPGStatus;\\"isActive\\": boolean;\\"isBussinessUser\\": boolean;\\"isPerson\\": boolean;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"userStatus\\": UserStatus;\\"displayName\\"?: string;\\"identityStatusDisplay\\"?: string;\\"imageUrl\\"?: string;\\"ipgStatusDisplay\\"?: string;\\"lastActivityDate\\"?: string;\\"phoneNumber\\"?: string;\\"registerDate\\"?: string;}
+        
+        
+        export interface ReselledUserFilterData {\\"identityStatuses\\"?:  & (DropDownResultOfIdentityStatus);}
+        
+        
+        export interface ResellerApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"commissionId\\": number;\\"commissionType\\": ComissionType;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endDate\\": string;\\"hasSubDomain\\": boolean;\\"isActive\\": boolean;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startDate\\": string;\\"commissionDisplay\\"?: string;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionFixedValue\\"?: number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionMaxValue\\"?: number;\\"commissionName\\"?: string;
+/**
+ * 
+ * - Format: double
+ */
+\\"commissionPercent\\"?: number;\\"commissionTypeDisplay\\"?: string;\\"endDateDisplay\\"?: string;\\"introduceLink\\"?: string;\\"startDateDisplay\\"?: string;}
+        
+        
+        export interface SendConnectionRequestInput {\\"email\\"?: string;\\"phoneNumber\\"?: string;\\"position\\"?: string;}
+        
+        
+        export enum SepidResponseType {Succesful=\\"Succesful\\",Unsuccesful=\\"Unsuccesful\\"}
+        
+        
+        export interface SetAccountAccessForSubUserInput {
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface SetUserBasicInfoInput {
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"firstName\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"introducerCode\\"?: number;\\"lastName\\"?: string;\\"password\\"?: string;}
+        
+        
+        export interface SettingApiModel {\\"logSetting\\"?:  & (LogSetting);}
+        
+        
+        export interface SubDomainApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"domainId\\": number;\\"isActive\\": boolean;
+/**
+ * 
+ * - Format: guid
+ */
+\\"resellerUserId\\": string;\\"about\\"?: string;\\"domainEnglishName\\"?: string;\\"domainPersianName\\"?: string;\\"englishName\\"?: string;\\"logoFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"logoFileUniqueId\\"?: string;\\"logoFileUrl\\"?: string;\\"persianName\\"?: string;\\"resellerUserDisplayName\\"?: string;\\"subDomainAddress\\"?: string;}
+        
+        
+        export interface SubDomainUpdateApiModel {\\"about\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"logoFileUniqueId\\"?: string;}
+        
+        
+        export interface SubUserAccountDetailQuery {\\"accountStatus\\": AccountStatus;\\"canAssistantsCreatesEpayRequest\\": boolean;\\"canChargeAccount\\": boolean;\\"canReceiveMoney\\": boolean;\\"canRequestSettlement\\": boolean;\\"canSeeEpayRequests\\": boolean;\\"canSeeSettlementRequests\\": boolean;\\"canSeeTransactions\\": boolean;\\"canTransferMoney\\": boolean;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"isActive\\": boolean;\\"notificationEnabled\\": boolean;
+/**
+ * 
+ * - Format: int32
+ */
+\\"posPaidCount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"posScanCount\\": number;\\"accountNumber\\"?: string;\\"accountQrCodeUrl\\"?: string;\\"accountStatusDisplay\\"?: string;\\"name\\"?: string;\\"posLinkUrl\\"?: string;}
+        
+        
+        export interface SubUserActivityApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"accountChargeRequestAmount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"accountChargeRequestCount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"paidEpayRequestAmount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"paidEpayRequestCount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"settlementRequestAmount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"settlementRequestCount\\": number;}
+        
+        
+        export interface SubUserConnectionApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"invitationId\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"requestDateTime\\": string;\\"status\\": SubUserConnectionStatus;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead,
+ */
+\\"subUserConnectionStatus\\":  & (SubUserConnectionStatus);\\"connectDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"connectDateTime\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"connectionId\\"?: number;\\"disconnectDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"disconnectDateTime\\"?: string;\\"removeDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"removeDateTime\\"?: string;\\"requestDate\\"?: string;\\"statusDisplay\\"?: string;\\"subUserAvatarUrl\\"?: string;\\"subUserContact\\"?: string;\\"subUserPositionTitle\\"?: string;\\"subUserTitle\\"?: string;}
+        
+        
+        export enum SubUserConnectionStatus {Pending=\\"Pending\\",Rejected=\\"Rejected\\",Connected=\\"Connected\\",Disconnected=\\"Disconnected\\",Deleted=\\"Deleted\\"}
+        
+        
+        export interface SubUserInvitationApiModel {
+/**
+ * 
+ * - Format: date-time
+ */
+\\"invitationDate\\": string;
+/**
+ * 
+ * [Deprecated, use 'InvitationToken' to call new endpoints]
+ * - Format: int64
+ * @deprecated Use 'InvitationToken' to call new endpoints.
+ */
+\\"invitationId\\": number;\\"businessUserAvatarUrl\\"?: string;\\"businessUserTitle\\"?: string;\\"invitationToken\\"?: string;\\"message\\"?: string;}
+        
+        
+        export interface SubUserNotificationStatusInput {\\"notificationEnabled\\": boolean;}
+        
+        
+        export interface SubUserPermissionApiModel {\\"canAccessToAccount\\": boolean;\\"canAssistantsCreatesEpayRequest\\": boolean;\\"canChargeAccount\\": boolean;\\"canGroupTransferMoney\\": boolean;\\"canReceiveMoney\\": boolean;\\"canRequestSettlement\\": boolean;\\"canSeeEpayRequests\\": boolean;\\"canSeeSettlementRequests\\": boolean;\\"canSeeTransactions\\": boolean;\\"canTransferMoney\\": boolean;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"realBalance\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"totalBalance\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"accountNumber\\"?: string;\\"accountTitle\\"?: string;}
+        
+        
+        export enum SubUserPermissionType {Default=\\"Default\\",CanReceiveMoney=\\"CanReceiveMoney\\",CanSeeEpayRequests=\\"CanSeeEpayRequests\\",CanTransferMoney=\\"CanTransferMoney\\",CanSeeTransactions=\\"CanSeeTransactions\\",CanRequestSettlement=\\"CanRequestSettlement\\",CanChargeAccount=\\"CanChargeAccount\\",CanSeeSettlementRequests=\\"CanSeeSettlementRequests\\",CanGroupTransferMoney=\\"CanGroupTransferMoney\\",CanAssistantsCreatesEpayRequest=\\"CanAssistantsCreatesEpayRequest\\"}
+        
+        
+        export interface SubuserInvitationTaskInput {\\"subuserInvitationTaskType\\": SubuserInvitationTaskType;}
+        
+        
+        export enum SubuserInvitationTaskType {Accept=\\"Accept\\",Reject=\\"Reject\\"}
+        
+        
+        export enum SubuserStatus {Connected=\\"Connected\\",DisconnectedByBusinessUser=\\"DisconnectedByBusinessUser\\",DisconnectedBySubUser=\\"DisconnectedBySubUser\\"}
+        
+        
+        export interface TaxiInfoOutput {\\"carTypeCode\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"lineCode\\": number;\\"activityType\\"?: string;\\"destination\\"?: string;\\"source\\"?: string;\\"vehicleColor\\"?: string;\\"vehicleType\\"?: string;}
+        
+        
+        export enum TaxiPaymentProvider {Sepid=\\"Sepid\\",Simorgh=\\"Simorgh\\"}
+        
+        
+        export interface TaxiPriceOutput {
+/**
+ * 
+ * - Format: int64
+ */
+\\"amount\\": number;\\"currency\\"?: string;\\"title\\"?: string;}
+        
+        
+        export interface TaxiRecieptApiDto {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"dateTime\\": string;\\"sepidResponse\\": SepidResponseType;\\"taxiProvider\\": TaxiPaymentProvider;\\"accountName\\"?: string;\\"accountNumber\\"?: string;\\"sepidResponseDisplay\\"?: string;\\"taxiProviderDisplay\\"?: string;}
+        
+        
+        export interface TerminalVersionApiModel {\\"currentVersion\\"?: string;\\"minimumVersion\\"?: string;}
+        
+        
+        export enum TerminalVersionState {Default=\\"Default\\",UpToDate=\\"UpToDate\\",Supported=\\"Supported\\",Deprecated=\\"Deprecated\\"}
+        
+        
+        export interface TotpLoginResult {\\"token\\"?: string;}
+        
+        
+        export interface TransactionApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"accountId\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDateTime\\": string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"remain\\": number;\\"transactionOperationType\\": TransactionOperationType;\\"transactionType\\": TransactionType;
+/**
+ * 
+ * - Format: int64
+ */
+\\"voucherId\\": number;\\"accountNumber\\"?: string;\\"accountTitle\\"?: string;\\"createDate\\"?: string;\\"description\\"?: string;\\"followupId\\"?: string;\\"logicalAction\\"?:  & (LogicalActionType);\\"logicalActionDisplay\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"targetBusinessCategoryId\\"?: number;\\"targetBusinessCategoryName\\"?: string;\\"transactionOperationTypeDisplay\\"?: string;\\"transactionTypeDisplay\\"?: string;\\"voucherType\\"?:  & (VoucherOperationType);\\"voucherTypeDisplay\\"?: string;}
+        
+        
+        export enum TransactionOperationType {Unknown=\\"Unknown\\",Normal=\\"Normal\\",System=\\"System\\",DomainCommission=\\"DomainCommission\\",ResellerCommission=\\"ResellerCommission\\",Block=\\"Block\\",Unblock=\\"Unblock\\",Refund=\\"Refund\\",NoCommissionRemainGift=\\"NoCommissionRemainGift\\",RemainGift=\\"RemainGift\\",DomainBankBatchTransfer=\\"DomainBankBatchTransfer\\",SettlementBatchTransferItem=\\"SettlementBatchTransferItem\\",Synchronization=\\"Synchronization\\",BlockchainWithdrawInternalTransfer=\\"BlockchainWithdrawInternalTransfer\\",BlockchainWithdrawUserWallet=\\"BlockchainWithdrawUserWallet\\",BlockchainIncomingTransaction=\\"BlockchainIncomingTransaction\\",BlockchainWithdrawUserWalletOffchain=\\"BlockchainWithdrawUserWalletOffchain\\",BlockchainFee=\\"BlockchainFee\\"}
+        
+        
+        export enum TransactionType {Debt=\\"Debt\\",Credit=\\"Credit\\"}
+        
+        
+        export interface TransferMoneyApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionAmount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'CommissionAmount' instead]
+ * - Format: decimal
+ * @deprecated Use 'CommissionAmount' instead.
+ */
+\\"domainCommissionAmount\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"payerAccountId\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"targetAccountId\\": number;
+/**
+ * 
+ * [Deprecated, use 'PayerAccountId' instead]
+ * - Format: int64
+ * @deprecated Use 'PayerAccountId' instead.
+ */
+\\"userAccountId\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"voucherId\\": number;\\"description\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'OperationId' instead]
+ * - Format: int64
+ * @deprecated Use 'OperationId' instead.
+ */
+\\"id\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"operationId\\"?: number;\\"payerAccountName\\"?: string;\\"payerAccountNumber\\"?: string;\\"targetAccountNumber\\"?: string;\\"targetUserAvatarUrl\\"?: string;\\"targetUserDisplayName\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'PayerAccountName' instead]
+ * @deprecated Use 'PayerAccountName' instead.
+ */
+\\"userAccountName\\"?: string;}
+        
+        
+        export interface TransferMoneyInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"targetUserAccountId\\": number;\\"description\\"?: string;\\"targetIdentifier\\"?: string;}
+        
+        
+        export interface UnreadNotificationCountApiModel {\\"channel\\": NotificationChannel;
+/**
+ * 
+ * - Format: int32
+ */
+\\"unreadCount\\": number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;}
+        
+        
+        export interface UpgradeToBusinessApiModel {\\"businessShareType\\": BusinessShareType;\\"businessType\\": BusinessType;\\"status\\": IdentityStatus;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"upgradeToBusinessRequestStatus\\":  & (IdentityStatus);
+/**
+ * 
+ * [Deprecated, use 'BusinessShareType' instead]
+ * @deprecated Use 'BusinessShareType' instead.
+ */
+\\"userIdentityType\\":  & (BusinessShareType);\\"address\\"?: string;\\"businessLogoImageLink\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"businessLogoImageUniqueId\\"?: string;\\"businessName\\"?: string;\\"businessShareTypeDisplay\\"?: string;\\"businessTypeDisplay\\"?: string;\\"city\\"?: string;\\"description\\"?: string;\\"documents\\"?: DocumentApiModel[];\\"email\\"?: string;\\"faxNumber\\"?: string;\\"managerName\\"?: string;\\"managerPhoneNumber\\"?: string;\\"organizationName\\"?: string;\\"organizationNationalCode\\"?: string;\\"personNationalCode\\"?: string;\\"phoneNumber\\"?: string;\\"rejectCause\\"?:  & (UpgradeToBusinessRejectCause);\\"rejectCauseDescription\\"?: string;\\"rejectCauseDisplay\\"?: string;\\"state\\"?: string;\\"statusDisplay\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'RejectCauseDescription' instead]
+ * @deprecated Use 'RejectCauseDescription' instead.
+ */
+\\"upgradeToBusinessRequestStatusDescription\\"?: string;\\"webSiteUrl\\"?: string;}
+        
+        
+        export enum UpgradeToBusinessRejectCause {DocumentsLack=\\"DocumentsLack\\",DocumentsMismatch=\\"DocumentsMismatch\\",Other=\\"Other\\"}
+        
+        
+        export interface UpgradeToBusinessUserInput {\\"address\\"?: string;\\"businessName\\"?: string;\\"businessShareType\\"?:  & (BusinessShareType);\\"businessType\\"?:  & (BusinessType);\\"city\\"?: string;\\"documents\\"?: DocumentInput[];\\"email\\"?: string;\\"faxNumber\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"logoFileUniqueId\\"?: string;\\"managerName\\"?: string;\\"managerPhoneNumber\\"?: string;\\"organizationName\\"?: string;\\"organizationNationalCode\\"?: string;\\"phoneNumber\\"?: string;\\"state\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'BusinessShareType' instead]
+ * @deprecated Use 'BusinessShareType' instead.
+ */
+\\"userIdentityType\\"?:  & (BusinessShareType);\\"webSiteUrl\\"?: string;}
+        
+        
+        export interface UserBankApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"bankId\\": number;\\"businessShareType\\": BusinessShareType;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;
+/**
+ * 
+ * [Deprecated, use 'BusinessShareType' instead]
+ * @deprecated Use 'BusinessShareType' instead.
+ */
+\\"identityType\\":  & (BusinessShareType);\\"isVisible\\": boolean;\\"status\\": IdentityStatus;\\"accountNumber\\"?: string;\\"bankLogo\\"?: string;\\"bankName\\"?: string;\\"businessShareTypeDisplay\\"?: string;\\"firstName\\"?: string;\\"lastName\\"?: string;\\"name\\"?: string;\\"rejectCause\\"?:  & (UserBankRejectCause);\\"rejectCauseDescription\\"?: string;\\"rejectCauseDisplay\\"?: string;\\"shebaNo\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'RejectCauseDescription' instead]
+ * @deprecated Use 'RejectCauseDescription' instead.
+ */
+\\"statusDescription\\"?: string;\\"statusDisplay\\"?: string;}
+        
+        
+        export interface UserBankChangeVisibilityInput {\\"isVisible\\"?: boolean;}
+        
+        
+        export type UserBankDetailApiModel =  & (UserBankApiModel & {\\"documents\\"?: DocumentApiModel[];\\"nationalCode\\"?: string;})
+        
+        
+        export interface UserBankInput {\\"accountNumber\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"bankId\\"?: number;\\"businessShareType\\"?:  & (BusinessShareType);\\"documents\\"?: DocumentInput[];\\"firstName\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'BusinessShareType' instead]
+ * @deprecated Use 'BusinessShareType' instead.
+ */
+\\"identityType\\"?:  & (BusinessShareType);\\"isVisible\\"?: boolean;\\"lastName\\"?: string;\\"name\\"?: string;\\"nationalCode\\"?: string;\\"shebaNo\\"?: string;}
+        
+        
+        export enum UserBankRejectCause {DocumentsLack=\\"DocumentsLack\\",DocumentsMismatch=\\"DocumentsMismatch\\",Etc=\\"Etc\\"}
+        
+        
+        export interface UserChangePasswordInput {\\"currentPassword\\"?: string;\\"newPassword\\"?: string;}
+        
+        
+        export type UserDetailQuery =  & (UserMeQuery & {\\"address\\"?: string;\\"city\\"?: string;\\"email\\"?: string;\\"introducedBySubDomain\\"?: string;\\"nationalCode\\"?: string;\\"phoneNumber\\"?: string;\\"state\\"?: string;})
+        
+        
+        export interface UserForgetPasswordInput {\\"phoneNumber\\"?: string;}
+        
+        
+        export enum UserIdentifierType {Default=\\"Default\\",PhoneNumber=\\"PhoneNumber\\",Email=\\"Email\\",CustomerNumber=\\"CustomerNumber\\",AccountNumber=\\"AccountNumber\\"}
+        
+        
+        export enum UserIdentityRejectCause {DocumentsLack=\\"DocumentsLack\\",DocumentsMismatch=\\"DocumentsMismatch\\",DocumentsRejected=\\"DocumentsRejected\\",Etc=\\"Etc\\"}
+        
+        
+        export interface UserIdentityRequestQuery {\\"status\\": IdentityStatus;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"userIdentityRequestStatus\\":  & (IdentityStatus);\\"documents\\"?: DocumentApiModel[];\\"firstName\\"?: string;\\"lastName\\"?: string;\\"nationalCode\\"?: string;\\"rejectCause\\"?:  & (UserIdentityRejectCause);\\"rejectCauseDescription\\"?: string;\\"rejectCauseDisplay\\"?: string;\\"statusDisplay\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'RejectCauseDescription' instead]
+ * @deprecated Use 'RejectCauseDescription' instead.
+ */
+\\"userIdentityRequestStatusDescription\\"?: string;}
+        
+        
+        export interface UserMeQuery {\\"identityStatus\\": IdentityStatus;\\"isBusinessUser\\": boolean;\\"isResellerUser\\": boolean;\\"isSubUser\\": boolean;
+/**
+ * 
+ * - Format: int64
+ */
+\\"shareCode\\": number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"birthDate\\"?: string;\\"birthDateDisplay\\"?: string;\\"businessName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"businessUserId\\"?: string;\\"gender\\"?:  & (Gender);\\"genderDisplay\\"?: string;\\"identityStatusDisplay\\"?: string;\\"profileImageLink\\"?: string;\\"referredBy\\"?: string;\\"title\\"?: string;}
+        
+        
+        export interface UserMinimalDto {
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"displayName\\"?: string;\\"positionTitle\\"?: string;}
+        
+        
+        export interface UserPluginApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"isActive\\": boolean;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"pluginConfig\\"?: string;\\"pluginName\\"?: string;\\"userDisplayName\\"?: string;}
+        
+        
+        export interface UserPluginDetailApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"isActive\\": boolean;
+/**
+ * 
+ * - Format: int32
+ */
+\\"pluginId\\": number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"pluginAmountCalculationExpression\\"?: string;\\"pluginConfig\\"?: string;\\"pluginLogoFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"pluginLogoFileUniqueId\\"?: string;\\"pluginLogoFileUrl\\"?: string;\\"pluginName\\"?: string;\\"properties\\"?: PluginPropertyApiModel[];\\"userDisplayName\\"?: string;}
+        
+        
+        export interface UserPluginTogggleApiModel {\\"isActive\\": boolean;}
+        
+        
+        export interface UserProfileAvatarInput {
+/**
+ * 
+ * - Format: guid
+ */
+\\"fileUniqueId\\"?: string;}
+        
+        
+        export interface UserProfileInput {\\"address\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"birthDate\\"?: string;\\"city\\"?: string;\\"email\\"?: string;\\"gender\\"?:  & (Gender);\\"state\\"?: string;}
+        
+        
+        export enum UserStatus {None=\\"None\\",NotVerified=\\"NotVerified\\",VerifiedButNotCompleted=\\"VerifiedButNotCompleted\\",Active=\\"Active\\",TemporaryBlocked=\\"TemporaryBlocked\\",AutoPasswordGenerated=\\"AutoPasswordGenerated\\"}
+        
+        
+        export interface UserVerifyForgetPasswordInput {\\"newPassword\\"?: string;\\"phoneNumber\\"?: string;\\"token\\"?: string;\\"verifyCode\\"?: string;}
+        
+        
+        export interface UserWorkspaceQuery {
+/**
+ * 
+ * - Format: guid
+ */
+\\"businessUserId\\": string;\\"workspaceType\\": WorkspaceType;\\"businessAvatarUrl\\"?: string;\\"businessName\\"?: string;\\"positionTitle\\"?: string;}
+        
+        
+        export interface VerifyPhoneNumberInput {
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"subDomainId\\"?: string;\\"token\\"?: string;\\"verifyCode\\"?: string;}
+        
+        
+        export enum VoucherOperationType {Unknown=\\"Unknown\\",EPayViaBankWithCommissionByPayer=\\"EPayViaBankWithCommissionByPayer\\",EPayViaBankWithCommissionByUser=\\"EPayViaBankWithCommissionByUser\\",EPayViaPSPWithCommissionByPayer=\\"EPayViaPSPWithCommissionByPayer\\",EPayViaPSPWithCommissionByUser=\\"EPayViaPSPWithCommissionByUser\\",EPayViaWalletWithCommissionByPayer=\\"EPayViaWalletWithCommissionByPayer\\",EPayViaWalletWithCommissionByUser=\\"EPayViaWalletWithCommissionByUser\\",TransferMoney=\\"TransferMoney\\",ChargeWallet=\\"ChargeWallet\\",ServiceBill=\\"ServiceBill\\",ServiceMobileCharge=\\"ServiceMobileCharge\\",POSViaBank=\\"POSViaBank\\",POSViaWallet=\\"POSViaWallet\\",ShareAndBlockRequest=\\"ShareAndBlockRequest\\",ShareRequest=\\"ShareRequest\\",SettlementAuto=\\"SettlementAuto\\",SettlementManual=\\"SettlementManual\\",SettlementSuspected=\\"SettlementSuspected\\",GroupTransferMoney=\\"GroupTransferMoney\\",ShareAndUnblock=\\"ShareAndUnblock\\",RefundWithSystemPayer=\\"RefundWithSystemPayer\\",RefundWithAnonymousPayer=\\"RefundWithAnonymousPayer\\",PayCommand=\\"PayCommand\\",GiftForReferrer=\\"GiftForReferrer\\",GiftForNoCommissionRemain=\\"GiftForNoCommissionRemain\\",Sepid=\\"Sepid\\",BatchTransferItem=\\"BatchTransferItem\\",AbstractProviderSynchronization=\\"AbstractProviderSynchronization\\",BlockchainWithdrawInternalTransfer=\\"BlockchainWithdrawInternalTransfer\\",BlockchainWithdrawUserWallet=\\"BlockchainWithdrawUserWallet\\",BlockchainIncomingTransaction=\\"BlockchainIncomingTransaction\\",BlockchainWithdrawUserWalletOnChain=\\"BlockchainWithdrawUserWalletOnChain\\"}
+        
+        
+        export type WalletDetailApiModel =  & (WalletDisplayApiModel & {\\"notificationEnabled\\": boolean;
+/**
+ * 
+ * - Format: int32
+ */
+\\"permittedSubuserCount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"posPaidCount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"posScanCount\\": number;\\"accountQrCodeUrl\\"?: string;\\"actionPolicies\\"?: CommissionPolicyApiModel[];\\"posLinkUrl\\"?: string;})
+        
+        
+        export interface WalletDisplayApiModel {\\"automaticSettlement\\": boolean;\\"getComissionFromPayer\\": boolean;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"isActive\\": boolean;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"realBalance\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"totalBalance\\": number;\\"directUserBankAccountNumber\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"directUserBankBankId\\"?: number;\\"directUserBankBankName\\"?: string;\\"directUserBankShebaNumber\\"?: string;\\"intermediateUserBankAccountNumber\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"intermediateUserBankBankId\\"?: number;\\"intermediateUserBankBankName\\"?: string;\\"intermediateUserBankShebaNumber\\"?: string;\\"number\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"relatedUserAccountIndex\\"?: number;\\"title\\"?: string;}
+        
+        
+        export interface WalletReceiptApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionAmount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDate\\": string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"payerAccountId\\": number;\\"callbackUrl\\"?: string;\\"creatorUserAvatarUrl\\"?: string;\\"creatorUserDisplayName\\"?: string;\\"description\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"operationId\\"?: number;\\"payerAccountName\\"?: string;\\"payerAccountNumber\\"?: string;\\"sharerUrl\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"targetAccountId\\"?: number;\\"targetAccountNumber\\"?: string;\\"targetUserAvatarUrl\\"?: string;\\"targetUserDisplayName\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"voucherId\\"?: number;}
+        
+        
+        export enum WorkspaceType {User=\\"User\\",SubUser=\\"SubUser\\"}
+        "
+`;
+
+exports[`only includes get methods does not ends with Id generate Code 1`] = `
+"
+//@ts-nocheck
+/**
+* AUTO_GENERATED Do not change this file directly, use config.ts file instead
+*
+* @version 6
+*/
+
+import type { AxiosRequestConfig } from \\"axios\\";
+import type { SwaggerResponse } from \\"./config\\";
+import { Http } from \\"./httpRequest\\";
+//@ts-ignore
+import qs from \\"qs\\";
+import type { GetBusinessUserConnectionQueryParams, GetBusinessUserConnectionActiveQueryParams, GetBusinessUserConnectionConnectionIdEpayQueryParams, GetEpayRequestQueryParams, GetEpayRequestExcelQueryParams, GetEpayRequestForMeQueryParams, GetEpayRequestUserWalletIdCommissionQueryParams, GetEpayRequestCountQueryParams, GetEpayRequestReportQueryParams, GetEpayRequestForMeCountQueryParams, GetEpayRequestForMeReportQueryParams, GetEpayRequestPosQrAccountNumberQueryParams, GetGroupTransferCommissionQueryParams, GetIntegrationQueryParams, GetKpiLastQueryParams, GetKpiCurrentQueryParams, GetKpiQueryParams, GetNotificationUnreadQueryParams, GetPosAccountNumberQueryParams, GetResellerUserIntroducedQueryParams, GetResellerUserDashboardCommissionSumQueryParams, GetResellerUserDashboardCommissionReportQueryParams, GetResellerUserDashboardLinksCountQueryParams, GetResellerUserDashboardLinksReportQueryParams, GetResellerUserDashboardLinksPaidCountQueryParams, GetResellerUserDashboardLinksPaidReportQueryParams, GetResellerUserDashboardTransactionsCountQueryParams, GetResellerUserDashboardTransactionsReportQueryParams, GetResellerUserDashboardIntroducedCountQueryParams, GetResellerUserDashboardIntroducedReportQueryParams, GetTransactionQueryParams, GetTransactionExcelQueryParams, GetTransactionReportQueryParams, GetTransactionReportAllQueryParams, GetTransferSearchQueryParams, GetTransferRecentQueryParams, GetTransferUserWalletIdCommissionQueryParams, GetUserWalletAccountNumberQrcodeQueryParams, GetUserWalletUserWalletIdSettlementRequestComissionQueryParams, GetUserWalletUserWalletIdEpayRequestComissionQueryParams, GetUserWalletSearchQueryParams, GetUserWalletUserWalletIdTransferMoneyCommissionQueryParams, BankApiModel, BusinessCategoryApiModel, SubUserConnectionApiModel, SubUserPermissionApiModel, SubUserActivityApiModel, EpayRequestApiModel, EpayRequestForUserQuery, ContactApiModel, CommissionAmountApiModel, UserMinimalDto, EpayRequestPublicInfoApiModel, WalletReceiptApiModel, AggregationApiModel, ReportApiModel, DriverInfoResult, KpiResult, ImportantActionApiModel, NotificationApiModel, UnreadNotificationCountApiModel, PosLandingPageApiModel, BankReceiptApiModel, ResellerApiModel, ReselledUserFilterData, ReselledUserApiModel, ReselledUserActivityApiModel, DateReportApiModelOfDecimal, DateReportApiModelOfInteger, SubDomainApiModel, BusinessUserConnectionApiModel, TransactionApiModel, AllTransactionsReportApiModel, AccountInfoApiModel, TransferMoneyApiModel, UserBankApiModel, UserDetailQuery, UserMeQuery, UserWorkspaceQuery, UserIdentityRequestQuery, UpgradeToBusinessApiModel, SubUserInvitationApiModel, UserPluginDetailApiModel, WalletDisplayApiModel, AccountBalanceApiModel, AccountPermittedSubUserQuery,}  from \\"./types\\"
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const __DEV__ = process.env.NODE_ENV !== \\"production\\";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function overrideConfig(
+  config?: AxiosRequestConfig,
+  configOverride?: AxiosRequestConfig,
+): AxiosRequestConfig {
+  return {
+    ...config,
+    ...configOverride,
+    headers: {
+      ...config?.headers,
+      ...configOverride?.headers,
+    },
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function template(path: string, obj: { [x: string]: any } = {}) {
+    Object.keys(obj).forEach((key) => {
+      const re = new RegExp(\`{\${key}}\`, \\"i\\");
+      path = path.replace(re, obj[key]);
+    });
+
+    return path;
+}
+
+function isFormData(obj: any) {
+  // This checks for the append method which should exist on FormData instances
+  return (
+    (typeof obj === \\"object\\" &&
+      typeof obj.append === \\"function\\" &&
+      obj[Symbol.toStringTag] === undefined) ||
+    obj[Symbol.toStringTag] === \\"FormData\\"
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function objToForm(requestBody: object) {
+  if (isFormData(requestBody)) {
+    return requestBody;
+  }
+  const formData = new FormData();
+
+  Object.entries(requestBody).forEach(([key, value]) => {
+    value && formData.append(key, value);
+  });
+
+  return formData;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function objToUrlencoded(requestBody: object) {
+  return qs.stringify(requestBody)
+}
+
+export const getAccessUserWalletIdLogicalAction = (
+    userWalletId: number,logicalAction: \\"EpayRequest\\" | \\"TransferMoney\\" | \\"AccountChargeRequest\\" | \\"ServiceBill\\" | \\"ServiceMobileCharge\\" | \\"POS\\" | \\"ShareAndBlockRequest\\" | \\"ShareRequest\\" | \\"Settlement\\" | \\"GroupTransferMoney\\" | \\"ShareAndUnblock\\" | \\"Refund\\" | \\"PayCommand\\" | \\"Gift\\" | \\"TaxiFairPayment\\" | \\"HitoBitFee\\",configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<boolean>> => {
+  
+  return Http.getRequest(
+    template(getAccessUserWalletIdLogicalAction.key,{userWalletId,logicalAction,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getAccessUserWalletIdLogicalAction.key = \\"/Access/{userWalletId}/{logicalAction}\\";
+
+
+/**
+ * 
+ * Get available banks
+ */
+export const getBank = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<BankApiModel[]>> => {
+  
+  return Http.getRequest(
+    getBank.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBank.key = \\"/Bank\\";
+
+
+/**
+ * 
+ * Get Business categories
+ */
+export const getBusinessUserCategory = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<BusinessCategoryApiModel[]>> => {
+  
+  return Http.getRequest(
+    getBusinessUserCategory.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBusinessUserCategory.key = \\"/BusinessUser/category\\";
+
+
+/**
+ * 
+ * Get the connections
+[Feature just allowed for the business users]
+ */
+export const getBusinessUserConnection = (
+    queryParams?: GetBusinessUserConnectionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<SubUserConnectionApiModel[]>> => {
+  
+  return Http.getRequest(
+    getBusinessUserConnection.key,
+    queryParams,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBusinessUserConnection.key = \\"/BusinessUser/connection\\";
+
+
+/**
+ * 
+ * Get active connections ordered by Transactions count
+[Feature just allowed for the business users]
+ */
+export const getBusinessUserConnectionActive = (
+    queryParams?: GetBusinessUserConnectionActiveQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<SubUserConnectionApiModel[]>> => {
+  
+  return Http.getRequest(
+    getBusinessUserConnectionActive.key,
+    queryParams,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBusinessUserConnectionActive.key = \\"/BusinessUser/connection/active\\";
+
+
+/**
+ * 
+ * Get the connection amounts report
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const getBusinessUserConnectionConnectionIdActivity = (
+    
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubUserActivityApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getBusinessUserConnectionConnectionIdActivity.key,{connectionId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBusinessUserConnectionConnectionIdActivity.key = \\"/BusinessUser/connection/{connectionId}/activity\\";
+
+export const getBusinessUserConnectionConnectionIdEpay = (
+    connectionId: number,queryParams?: GetBusinessUserConnectionConnectionIdEpayQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<EpayRequestApiModel[]>> => {
+  
+  return Http.getRequest(
+    template(getBusinessUserConnectionConnectionIdEpay.key,{connectionId,}),
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBusinessUserConnectionConnectionIdEpay.key = \\"/BusinessUser/connection/{connectionId}/epay\\";
+
+
+/**
+ * 
+ * Get sub user permissions for accounts
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const getBusinessUserConnectionConnectionIdPermission = (
+    
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<SubUserPermissionApiModel[]>> => {
+  
+  return Http.getRequest(
+    template(getBusinessUserConnectionConnectionIdPermission.key,{connectionId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBusinessUserConnectionConnectionIdPermission.key = \\"/BusinessUser/connection/{connectionId}/permission\\";
+
+export const getEpayRequest = (
+    queryParams?: GetEpayRequestQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<EpayRequestApiModel[]>> => {
+  
+  return Http.getRequest(
+    getEpayRequest.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequest.key = \\"/EpayRequest\\";
+
+export const getEpayRequestAudiencesRecent = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<ContactApiModel[]>> => {
+  
+  return Http.getRequest(
+    getEpayRequestAudiencesRecent.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestAudiencesRecent.key = \\"/EpayRequest/audiences/recent\\";
+
+export const getEpayRequestCount = (
+    queryParams?: GetEpayRequestCountQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AggregationApiModel)>> => {
+  
+  return Http.getRequest(
+    getEpayRequestCount.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestCount.key = \\"/EpayRequest/count\\";
+
+export const getEpayRequestEpayTokenDetail = (
+    epayToken: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (EpayRequestPublicInfoApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getEpayRequestEpayTokenDetail.key,{epayToken,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestEpayTokenDetail.key = \\"/EpayRequest/{epayToken}/detail\\";
+
+
+/**
+ * 
+ * Get QR code image file for epay request
+ */
+export const getEpayRequestEpayTokenQrcode = (
+    
+/**
+ * 
+ * epay request token
+ */
+epayToken: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    template(getEpayRequestEpayTokenQrcode.key,{epayToken,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestEpayTokenQrcode.key = \\"/EpayRequest/{epayToken}/qrcode\\";
+
+export const getEpayRequestExcel = (
+    queryParams?: GetEpayRequestExcelQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    getEpayRequestExcel.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestExcel.key = \\"/EpayRequest/excel\\";
+
+
+/**
+ * 
+ * Get pay requests that the user is one of its audiences.
+[Feature is not allowed for sub users]
+[Needs secure login]
+ */
+export const getEpayRequestForMe = (
+    queryParams?: GetEpayRequestForMeQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<EpayRequestForUserQuery[]>> => {
+  
+  return Http.getRequest(
+    getEpayRequestForMe.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestForMe.key = \\"/EpayRequest/forMe\\";
+
+export const getEpayRequestForMeCount = (
+    queryParams?: GetEpayRequestForMeCountQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AggregationApiModel)>> => {
+  
+  return Http.getRequest(
+    getEpayRequestForMeCount.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestForMeCount.key = \\"/EpayRequest/forMe/count\\";
+
+export const getEpayRequestForMeReport = (
+    queryParams?: GetEpayRequestForMeReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<ReportApiModel[]>> => {
+  
+  return Http.getRequest(
+    getEpayRequestForMeReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestForMeReport.key = \\"/EpayRequest/forMe/report\\";
+
+
+/**
+ * 
+ * [Deprecated, use 'account/{accountNumber}/qrcode' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getEpayRequestPosQrAccountNumber = (
+    accountNumber: string,queryParams?: GetEpayRequestPosQrAccountNumberQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getEpayRequestPosQrAccountNumber\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    template(getEpayRequestPosQrAccountNumber.key,{accountNumber,}),
+    queryParams,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestPosQrAccountNumber.key = \\"/EpayRequest/pos/Qr/{accountNumber}\\";
+
+export const getEpayRequestReport = (
+    queryParams?: GetEpayRequestReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<ReportApiModel[]>> => {
+  
+  return Http.getRequest(
+    getEpayRequestReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestReport.key = \\"/EpayRequest/report\\";
+
+
+/**
+ * 
+ * Get comission amount for epay request amount
+ */
+export const getEpayRequestUserWalletIdCommission = (
+    userWalletId: number,queryParams?: GetEpayRequestUserWalletIdCommissionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (CommissionAmountApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getEpayRequestUserWalletIdCommission.key,{userWalletId,}),
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestUserWalletIdCommission.key = \\"/EpayRequest/{userWalletId}/commission\\";
+
+export const getEpayRequestUserWalletIdCreators = (
+    userWalletId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<UserMinimalDto[]>> => {
+  
+  return Http.getRequest(
+    template(getEpayRequestUserWalletIdCreators.key,{userWalletId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestUserWalletIdCreators.key = \\"/EpayRequest/{userWalletId}/creators\\";
+
+export const getError = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    getError.key,
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getError.key = \\"/error\\";
+
+export const getErrorLocal = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    getErrorLocal.key,
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getErrorLocal.key = \\"/error/local\\";
+
+export const getErrorStatusCode = (
+    code: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    template(getErrorStatusCode.key,{code,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getErrorStatusCode.key = \\"/error/status/{code}\\";
+
+
+/**
+ * 
+ * Download a file.
+ */
+export const getFileFileGuid = (
+    
+/**
+ * 
+ * file unique id
+ */
+fileGuid: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    template(getFileFileGuid.key,{fileGuid,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getFileFileGuid.key = \\"/File/{fileGuid}\\";
+
+export const getGroupTransferCommission = (
+    queryParams?: GetGroupTransferCommissionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (CommissionAmountApiModel)>> => {
+  
+  return Http.getRequest(
+    getGroupTransferCommission.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getGroupTransferCommission.key = \\"/GroupTransfer/commission\\";
+
+
+/**
+ * 
+ * Get detailed driver,taxi and fair amount information
+ */
+export const getIntegration = (
+    queryParams?: GetIntegrationQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (DriverInfoResult)>> => {
+  
+  return Http.getRequest(
+    getIntegration.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT4,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getIntegration.key = \\"/Integration\\";
+
+export const getKpi = (
+    queryParams?: GetKpiQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<KpiResult[]>> => {
+  
+  return Http.getRequest(
+    getKpi.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getKpi.key = \\"/Kpi\\";
+
+export const getKpiCurrent = (
+    queryParams?: GetKpiCurrentQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<KpiResult[]>> => {
+  
+  return Http.getRequest(
+    getKpiCurrent.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getKpiCurrent.key = \\"/Kpi/Current\\";
+
+export const getKpiLast = (
+    queryParams?: GetKpiLastQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<KpiResult[]>> => {
+  
+  return Http.getRequest(
+    getKpiLast.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getKpiLast.key = \\"/Kpi/Last\\";
+
+
+/**
+ * 
+ * Get all Important Actions of current user.
+ */
+export const getNotificationIa = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<ImportantActionApiModel[]>> => {
+  
+  return Http.getRequest(
+    getNotificationIa.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getNotificationIa.key = \\"/Notification/ia\\";
+
+
+/**
+ * 
+ * Get Notifications of current user.
+Maximum 99 items will be returned.
+ */
+export const getNotificationNotif = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<NotificationApiModel[]>> => {
+  
+  return Http.getRequest(
+    getNotificationNotif.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getNotificationNotif.key = \\"/Notification/notif\\";
+
+export const getNotificationUnread = (
+    queryParams?: GetNotificationUnreadQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<UnreadNotificationCountApiModel[]>> => {
+  
+  return Http.getRequest(
+    getNotificationUnread.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getNotificationUnread.key = \\"/Notification/unread\\";
+
+
+/**
+ * 
+ * Get epay request detail
+ */
+export const getPosAccountNumber = (
+    
+/**
+ * 
+ * Account Number
+ */
+accountNumber: string,queryParams?: GetPosAccountNumberQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (PosLandingPageApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getPosAccountNumber.key,{accountNumber,}),
+    queryParams,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getPosAccountNumber.key = \\"/Pos/{accountNumber}\\";
+
+
+/**
+ * 
+ * Get bank receipt by EPayRequest token
+[For anonymous users]
+[Deprecated, use 'receipt/bank/{epayTryId}' and 'receipt/bank/{epayTryId}' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getReceiptEpayToken = (
+    
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (BankReceiptApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getReceiptEpayToken\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    template(getReceiptEpayToken.key,{epayToken,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getReceiptEpayToken.key = \\"/Receipt/{epayToken}\\";
+
+
+/**
+ * 
+ * Get wallet receipt by EPayRequest token
+[For anonymous users]
+ */
+export const getReceiptWalletEpayToken = (
+    
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (WalletReceiptApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getReceiptWalletEpayToken.key,{epayToken,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getReceiptWalletEpayToken.key = \\"/Receipt/wallet/{epayToken}\\";
+
+
+/**
+ * 
+ * Get the Resellership info of current Reseller user
+[Feature just allowed for Resellers]
+ */
+export const getResellerUser = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (ResellerApiModel)>> => {
+  
+  return Http.getRequest(
+    getResellerUser.key,
+    undefined,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUser.key = \\"/ResellerUser\\";
+
+
+/**
+ * 
+ * Get the time-based report of commissions paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardCommissionReport = (
+    queryParams?: GetResellerUserDashboardCommissionReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<DateReportApiModelOfDecimal[]>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardCommissionReport\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardCommissionReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardCommissionReport.key = \\"/ResellerUser/dashboard/commission/report\\";
+
+
+/**
+ * 
+ * Get sum of all commissions paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardCommissionSum = (
+    queryParams?: GetResellerUserDashboardCommissionSumQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AggregationApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardCommissionSum\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardCommissionSum.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardCommissionSum.key = \\"/ResellerUser/dashboard/commission/sum\\";
+
+
+/**
+ * 
+ * Get count of all users reselled by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardIntroducedCount = (
+    queryParams?: GetResellerUserDashboardIntroducedCountQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AggregationApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardIntroducedCount\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardIntroducedCount.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardIntroducedCount.key = \\"/ResellerUser/dashboard/introduced/count\\";
+
+
+/**
+ * 
+ * Get time-based report of users reselled by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardIntroducedReport = (
+    queryParams?: GetResellerUserDashboardIntroducedReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<DateReportApiModelOfInteger[]>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardIntroducedReport\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardIntroducedReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardIntroducedReport.key = \\"/ResellerUser/dashboard/introduced/report\\";
+
+
+/**
+ * 
+ * Get count of all links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardLinksCount = (
+    queryParams?: GetResellerUserDashboardLinksCountQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AggregationApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardLinksCount\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardLinksCount.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardLinksCount.key = \\"/ResellerUser/dashboard/links/count\\";
+
+
+/**
+ * 
+ * Get count of all paid links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardLinksPaidCount = (
+    queryParams?: GetResellerUserDashboardLinksPaidCountQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AggregationApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardLinksPaidCount\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardLinksPaidCount.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardLinksPaidCount.key = \\"/ResellerUser/dashboard/links/paid/count\\";
+
+
+/**
+ * 
+ * Get time-based report of paid links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardLinksPaidReport = (
+    queryParams?: GetResellerUserDashboardLinksPaidReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<DateReportApiModelOfInteger[]>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardLinksPaidReport\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardLinksPaidReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardLinksPaidReport.key = \\"/ResellerUser/dashboard/links/paid/report\\";
+
+
+/**
+ * 
+ * Get time-based report of links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardLinksReport = (
+    queryParams?: GetResellerUserDashboardLinksReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<DateReportApiModelOfInteger[]>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardLinksReport\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardLinksReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardLinksReport.key = \\"/ResellerUser/dashboard/links/report\\";
+
+
+/**
+ * 
+ * Get count of all commission transactions, paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardTransactionsCount = (
+    queryParams?: GetResellerUserDashboardTransactionsCountQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AggregationApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardTransactionsCount\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardTransactionsCount.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardTransactionsCount.key = \\"/ResellerUser/dashboard/transactions/count\\";
+
+
+/**
+ * 
+ * Get time-based report of commission transactions, paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardTransactionsReport = (
+    queryParams?: GetResellerUserDashboardTransactionsReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<DateReportApiModelOfInteger[]>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardTransactionsReport\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardTransactionsReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardTransactionsReport.key = \\"/ResellerUser/dashboard/transactions/report\\";
+
+
+/**
+ * 
+ * Get the Users Introduced by current Reseller user
+[Feature just allowed for Resellers]
+ */
+export const getResellerUserIntroduced = (
+    queryParams?: GetResellerUserIntroducedQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<ReselledUserApiModel[]>> => {
+  
+  return Http.getRequest(
+    getResellerUserIntroduced.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserIntroduced.key = \\"/ResellerUser/introduced\\";
+
+
+/**
+ * 
+ * Get filter data items to populate DropDowns
+[Feature just allowed for Resellers]
+ */
+export const getResellerUserIntroducedFilterData = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (ReselledUserFilterData)>> => {
+  
+  return Http.getRequest(
+    getResellerUserIntroducedFilterData.key,
+    undefined,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserIntroducedFilterData.key = \\"/ResellerUser/introduced/filterData\\";
+
+
+/**
+ * 
+ * Get the User activity
+[Feature just allowed for Resellers]
+ */
+export const getResellerUserIntroducedUserIdActivity = (
+    userId: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (ReselledUserActivityApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getResellerUserIntroducedUserIdActivity.key,{userId,}),
+    undefined,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserIntroducedUserIdActivity.key = \\"/ResellerUser/introduced/{userId}/activity\\";
+
+
+/**
+ * 
+ * Get the SubDomain of current Reseller user
+[Feature just allowed for Resellers]
+ */
+export const getSubDomain = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubDomainApiModel)>> => {
+  
+  return Http.getRequest(
+    getSubDomain.key,
+    undefined,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT4,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getSubDomain.key = \\"/SubDomain\\";
+
+
+/**
+ * 
+ * Get info of a SubDomain by it's address.
+ */
+export const getSubDomainSubDomainAddress = (
+    
+/**
+ * 
+ * The SubDomain part of the url.
+            
+ */
+subDomainAddress: string,headerParams?: {
+/**
+ * 
+ * - Format: guid
+ */
+\\"clientId\\": string;},configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubDomainApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getSubDomainSubDomainAddress.key,{subDomainAddress,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig({
+              headers:{
+                ..._CONSTANT6,
+                ...headerParams,
+              },
+            },
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getSubDomainSubDomainAddress.key = \\"/SubDomain/{subDomainAddress}\\";
+
+
+/**
+ * 
+ * Get the connections
+[Feature just allowed for SubUsers]
+[Deprecated. use 'user/connection' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getSubUserConnection = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<BusinessUserConnectionApiModel[]>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getSubUserConnection\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getSubUserConnection.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getSubUserConnection.key = \\"/SubUser/connection\\";
+
+export const getTransaction = (
+    queryParams?: GetTransactionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<TransactionApiModel[]>> => {
+  
+  return Http.getRequest(
+    getTransaction.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransaction.key = \\"/Transaction\\";
+
+export const getTransactionExcel = (
+    queryParams?: GetTransactionExcelQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    getTransactionExcel.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransactionExcel.key = \\"/Transaction/excel\\";
+
+
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getTransactionReport = (
+    queryParams?: GetTransactionReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<ReportApiModel[]>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getTransactionReport\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getTransactionReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransactionReport.key = \\"/Transaction/report\\";
+
+
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getTransactionReportAll = (
+    queryParams?: GetTransactionReportAllQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AllTransactionsReportApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getTransactionReportAll\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getTransactionReportAll.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransactionReportAll.key = \\"/Transaction/report/all\\";
+
+
+/**
+ * 
+ * Get recent money transfers
+ */
+export const getTransferRecent = (
+    queryParams?: GetTransferRecentQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<TransferMoneyApiModel[]>> => {
+  
+  return Http.getRequest(
+    getTransferRecent.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransferRecent.key = \\"/Transfer/recent\\";
+
+export const getTransferSearch = (
+    queryParams?: GetTransferSearchQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AccountInfoApiModel)>> => {
+  
+  return Http.getRequest(
+    getTransferSearch.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransferSearch.key = \\"/Transfer/search\\";
+
+
+/**
+ * 
+ * Get commission amount for transfer money amount
+ */
+export const getTransferUserWalletIdCommission = (
+    userWalletId: number,queryParams?: GetTransferUserWalletIdCommissionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (CommissionAmountApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getTransferUserWalletIdCommission.key,{userWalletId,}),
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransferUserWalletIdCommission.key = \\"/Transfer/{userWalletId}/commission\\";
+
+
+/**
+ * 
+ * Get [normal/sub/business] user profile detail
+ */
+export const getUser = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (UserDetailQuery)>> => {
+  
+  return Http.getRequest(
+    getUser.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUser.key = \\"/User\\";
+
+
+/**
+ * 
+ * Get user banks
+[Feature is not allowed for sub users.]
+ */
+export const getUserBank = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<UserBankApiModel[]>> => {
+  
+  return Http.getRequest(
+    getUserBank.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserBank.key = \\"/UserBank\\";
+
+
+/**
+ * 
+ * Get available user banks
+[Feature is not allowed for sub users.]
+ */
+export const getUserBankReady = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<UserBankApiModel[]>> => {
+  
+  return Http.getRequest(
+    getUserBankReady.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserBankReady.key = \\"/UserBank/ready\\";
+
+
+/**
+ * 
+ * Get the connections [Feature is allowed for normal users noly]
+ */
+export const getUserConnection = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<BusinessUserConnectionApiModel[]>> => {
+  
+  return Http.getRequest(
+    getUserConnection.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserConnection.key = \\"/User/connection\\";
+
+export const getUserContactInput = (
+    input: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (ContactApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getUserContactInput.key,{input,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserContactInput.key = \\"/User/contact/{input}\\";
+
+
+/**
+ * 
+ * Get last national id verification request [Feature is not allowed for sub users]
+ */
+export const getUserIdentityRequest = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (UserIdentityRequestQuery)>> => {
+  
+  return Http.getRequest(
+    getUserIdentityRequest.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserIdentityRequest.key = \\"/User/identityRequest\\";
+
+
+/**
+ * 
+ * Get business user invitations for me [Feature is not allowed for sub users]
+ */
+export const getUserInvitation = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<SubUserInvitationApiModel[]>> => {
+  
+  return Http.getRequest(
+    getUserInvitation.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserInvitation.key = \\"/User/invitation\\";
+
+
+/**
+ * 
+ * Get business user invitations for me [Feature is not allowed for sub users]
+ */
+export const getUserInvitationInvitationToken = (
+    invitationToken: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubUserInvitationApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getUserInvitationInvitationToken.key,{invitationToken,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserInvitationInvitationToken.key = \\"/User/invitation/{invitationToken}\\";
+
+
+/**
+ * 
+ * Get user profile summary
+ */
+export const getUserMe = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (UserMeQuery)>> => {
+  
+  return Http.getRequest(
+    getUserMe.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserMe.key = \\"/User/me\\";
+
+export const getUserPlugin = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<UserPluginDetailApiModel[]>> => {
+  
+  return Http.getRequest(
+    getUserPlugin.key,
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserPlugin.key = \\"/UserPlugin\\";
+
+
+/**
+ * 
+ * Get Last Request for upgrade account to the business [Feature is allowed for normal users only]
+ */
+export const getUserUpgradeToBusinessRequest = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (UpgradeToBusinessApiModel)>> => {
+  
+  return Http.getRequest(
+    getUserUpgradeToBusinessRequest.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserUpgradeToBusinessRequest.key = \\"/User/upgradeToBusinessRequest\\";
+
+export const getUserWallet = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<WalletDisplayApiModel[]>> => {
+  
+  return Http.getRequest(
+    getUserWallet.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWallet.key = \\"/UserWallet\\";
+
+export const getUserWalletAccountNumberQrcode = (
+    accountNumber: string,queryParams?: GetUserWalletAccountNumberQrcodeQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    template(getUserWalletAccountNumberQrcode.key,{accountNumber,}),
+    queryParams,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletAccountNumberQrcode.key = \\"/UserWallet/{accountNumber}/qrcode\\";
+
+
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getUserWalletSearch = (
+    queryParams?: GetUserWalletSearchQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AccountInfoApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getUserWalletSearch\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getUserWalletSearch.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletSearch.key = \\"/UserWallet/search\\";
+
+
+/**
+ * 
+ * Get user account balance
+ */
+export const getUserWalletUserWalletIdBalance = (
+    userWalletId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AccountBalanceApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getUserWalletUserWalletIdBalance.key,{userWalletId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletUserWalletIdBalance.key = \\"/UserWallet/{userWalletId}/balance\\";
+
+
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getUserWalletUserWalletIdEpayRequestComission = (
+    userWalletId: number,queryParams?: GetUserWalletUserWalletIdEpayRequestComissionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (CommissionAmountApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getUserWalletUserWalletIdEpayRequestComission\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    template(getUserWalletUserWalletIdEpayRequestComission.key,{userWalletId,}),
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletUserWalletIdEpayRequestComission.key = \\"/UserWallet/{userWalletId}/epayRequest/comission\\";
+
+export const getUserWalletUserWalletIdPermittedsubusers = (
+    userWalletId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<AccountPermittedSubUserQuery[]>> => {
+  
+  return Http.getRequest(
+    template(getUserWalletUserWalletIdPermittedsubusers.key,{userWalletId,}),
+    undefined,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletUserWalletIdPermittedsubusers.key = \\"/UserWallet/{userWalletId}/permittedsubusers\\";
+
+export const getUserWalletUserWalletIdSettlementRequestComission = (
+    userWalletId: number,queryParams?: GetUserWalletUserWalletIdSettlementRequestComissionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (CommissionAmountApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getUserWalletUserWalletIdSettlementRequestComission.key,{userWalletId,}),
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletUserWalletIdSettlementRequestComission.key = \\"/UserWallet/{userWalletId}/settlementRequest/comission\\";
+
+
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getUserWalletUserWalletIdTransferMoneyCommission = (
+    userWalletId: number,queryParams?: GetUserWalletUserWalletIdTransferMoneyCommissionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (CommissionAmountApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getUserWalletUserWalletIdTransferMoneyCommission\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    template(getUserWalletUserWalletIdTransferMoneyCommission.key,{userWalletId,}),
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletUserWalletIdTransferMoneyCommission.key = \\"/UserWallet/{userWalletId}/transferMoney/commission\\";
+
+
+/**
+ * 
+ * Get user work spaces
+ */
+export const getUserWorkspace = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<UserWorkspaceQuery[]>> => {
+  
+  return Http.getRequest(
+    getUserWorkspace.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWorkspace.key = \\"/User/workspace\\";
+export const _CONSTANT0 = {
+              headers: {
+                \\"Content-Type\\": \\"application/json\\",
+                Accept: \\"application/json\\",
+              },
+            };export const _CONSTANT1 = [{\\"bearer\\":[]}];export const _CONSTANT2 = [{\\"bearer\\":[\\"Business\\"]}];export const _CONSTANT3 = {
+              headers: {
+                \\"Content-Type\\": \\"application/json\\",
+                Accept: \\"*/*\\",
+              },
+            };export const _CONSTANT4 = {
+              headers: {
+                \\"Content-Type\\": \\"application/json\\",
+                Accept: \\"text/plain\\",
+              },
+            };export const _CONSTANT5 = [{\\"bearer\\":[\\"Reseller\\"]}];export const _CONSTANT6 = {
+                  \\"Content-Type\\": \\"application/json\\",
+                  Accept: \\"text/plain\\",
+
+                };"
+`;
+
+exports[`only includes get methods does not ends with Id generate hooks 1`] = `
+"
+//@ts-nocheck
+/**
+* AUTO_GENERATED Do not change this file directly, use config.ts file instead
+*
+* @version 6
+*/
+
+
+import { AxiosRequestConfig } from \\"axios\\";
+import {
+  UseQueryOptions,
+  useQuery,
+  useMutation,
+  UseMutationOptions,
+  
+  QueryClient,
+  QueryKey,
+} from \\"@tanstack/react-query\\";
+import { RequestError, SwaggerResponse } from \\"./config\\";
+
+import type { AccountBalanceApiModel, AccountInfoApiModel, AccountPermittedSubUserQuery, AggregationApiModel, AllTransactionsReportApiModel, BankApiModel, BankReceiptApiModel, BusinessCategoryApiModel, BusinessUserConnectionApiModel, CommissionAmountApiModel, ContactApiModel, DateReportApiModelOfDecimal, DateReportApiModelOfInteger, DriverInfoResult, EpayRequestApiModel, EpayRequestForUserQuery, EpayRequestPublicInfoApiModel, GetBusinessUserConnectionActiveQueryParams, GetBusinessUserConnectionConnectionIdEpayQueryParams, GetBusinessUserConnectionQueryParams, GetEpayRequestCountQueryParams, GetEpayRequestExcelQueryParams, GetEpayRequestForMeCountQueryParams, GetEpayRequestForMeQueryParams, GetEpayRequestForMeReportQueryParams, GetEpayRequestPosQrAccountNumberQueryParams, GetEpayRequestQueryParams, GetEpayRequestReportQueryParams, GetEpayRequestUserWalletIdCommissionQueryParams, GetGroupTransferCommissionQueryParams, GetIntegrationQueryParams, GetKpiCurrentQueryParams, GetKpiLastQueryParams, GetKpiQueryParams, GetNotificationUnreadQueryParams, GetPosAccountNumberQueryParams, GetResellerUserDashboardCommissionReportQueryParams, GetResellerUserDashboardCommissionSumQueryParams, GetResellerUserDashboardIntroducedCountQueryParams, GetResellerUserDashboardIntroducedReportQueryParams, GetResellerUserDashboardLinksCountQueryParams, GetResellerUserDashboardLinksPaidCountQueryParams, GetResellerUserDashboardLinksPaidReportQueryParams, GetResellerUserDashboardLinksReportQueryParams, GetResellerUserDashboardTransactionsCountQueryParams, GetResellerUserDashboardTransactionsReportQueryParams, GetResellerUserIntroducedQueryParams, GetTransactionExcelQueryParams, GetTransactionQueryParams, GetTransactionReportAllQueryParams, GetTransactionReportQueryParams, GetTransferRecentQueryParams, GetTransferSearchQueryParams, GetTransferUserWalletIdCommissionQueryParams, GetUserWalletAccountNumberQrcodeQueryParams, GetUserWalletSearchQueryParams, GetUserWalletUserWalletIdEpayRequestComissionQueryParams, GetUserWalletUserWalletIdSettlementRequestComissionQueryParams, GetUserWalletUserWalletIdTransferMoneyCommissionQueryParams, ImportantActionApiModel, KpiResult, NotificationApiModel, PosLandingPageApiModel, ReportApiModel, ReselledUserActivityApiModel, ReselledUserApiModel, ReselledUserFilterData, ResellerApiModel, SubDomainApiModel, SubUserActivityApiModel, SubUserConnectionApiModel, SubUserInvitationApiModel, SubUserPermissionApiModel, TransactionApiModel, TransferMoneyApiModel, UnreadNotificationCountApiModel, UpgradeToBusinessApiModel, UserBankApiModel, UserDetailQuery, UserIdentityRequestQuery, UserMeQuery, UserMinimalDto, UserPluginDetailApiModel, UserWorkspaceQuery, WalletDisplayApiModel, WalletReceiptApiModel,}  from \\"./types\\"
+import { getAccessUserWalletIdLogicalAction, getBank, getBusinessUserCategory, getBusinessUserConnection, getBusinessUserConnectionActive, getBusinessUserConnectionConnectionIdActivity, getBusinessUserConnectionConnectionIdEpay, getBusinessUserConnectionConnectionIdPermission, getEpayRequest, getEpayRequestAudiencesRecent, getEpayRequestCount, getEpayRequestEpayTokenDetail, getEpayRequestEpayTokenQrcode, getEpayRequestExcel, getEpayRequestForMe, getEpayRequestForMeCount, getEpayRequestForMeReport, getEpayRequestPosQrAccountNumber, getEpayRequestReport, getEpayRequestUserWalletIdCommission, getEpayRequestUserWalletIdCreators, getError, getErrorLocal, getErrorStatusCode, getFileFileGuid, getGroupTransferCommission, getIntegration, getKpi, getKpiCurrent, getKpiLast, getNotificationIa, getNotificationNotif, getNotificationUnread, getPosAccountNumber, getReceiptEpayToken, getReceiptWalletEpayToken, getResellerUser, getResellerUserDashboardCommissionReport, getResellerUserDashboardCommissionSum, getResellerUserDashboardIntroducedCount, getResellerUserDashboardIntroducedReport, getResellerUserDashboardLinksCount, getResellerUserDashboardLinksPaidCount, getResellerUserDashboardLinksPaidReport, getResellerUserDashboardLinksReport, getResellerUserDashboardTransactionsCount, getResellerUserDashboardTransactionsReport, getResellerUserIntroduced, getResellerUserIntroducedFilterData, getResellerUserIntroducedUserIdActivity, getSubDomain, getSubDomainSubDomainAddress, getSubUserConnection, getTransaction, getTransactionExcel, getTransactionReport, getTransactionReportAll, getTransferRecent, getTransferSearch, getTransferUserWalletIdCommission, getUser, getUserBank, getUserBankReady, getUserConnection, getUserContactInput, getUserIdentityRequest, getUserInvitation, getUserInvitationInvitationToken, getUserMe, getUserPlugin, getUserUpgradeToBusinessRequest, getUserWallet, getUserWalletAccountNumberQrcode, getUserWalletSearch, getUserWalletUserWalletIdBalance, getUserWalletUserWalletIdEpayRequestComission, getUserWalletUserWalletIdPermittedsubusers, getUserWalletUserWalletIdSettlementRequestComission, getUserWalletUserWalletIdTransferMoneyCommission, getUserWorkspace,}  from \\"./services\\"
+
+    export type SwaggerTypescriptMutationDefaultParams<TExtra> = {_extraVariables?:TExtra, configOverride?:AxiosRequestConfig}
+    type SwaggerTypescriptUseQueryOptions<TData> = Omit<UseQueryOptions<SwaggerResponse<TData>,RequestError | Error>,\\"queryKey\\">;
+
+    type SwaggerTypescriptUseMutationOptions<TData, TRequest, TExtra> = UseMutationOptions<
+      SwaggerResponse<TData>,
+      RequestError | Error,
+      TRequest & SwaggerTypescriptMutationDefaultParams<TExtra>
+    >;
+
+    type SwaggerTypescriptUseMutationOptionsVoid<
+      TData,
+      TExtra
+    > = UseMutationOptions<
+      SwaggerResponse<TData>,
+      RequestError | Error,
+      SwaggerTypescriptMutationDefaultParams<TExtra> | void
+    >;  
+    
+      export const useGetAccessUserWalletIdLogicalAction = (
+           userWalletId: number,logicalAction: \\"EpayRequest\\" | \\"TransferMoney\\" | \\"AccountChargeRequest\\" | \\"ServiceBill\\" | \\"ServiceMobileCharge\\" | \\"POS\\" | \\"ShareAndBlockRequest\\" | \\"ShareRequest\\" | \\"Settlement\\" | \\"GroupTransferMoney\\" | \\"ShareAndUnblock\\" | \\"Refund\\" | \\"PayCommand\\" | \\"Gift\\" | \\"TaxiFairPayment\\" | \\"HitoBitFee\\",options?:SwaggerTypescriptUseQueryOptions<boolean>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetAccessUserWalletIdLogicalAction.info( userWalletId,logicalAction,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetAccessUserWalletIdLogicalAction.info = (userWalletId: number,logicalAction: \\"EpayRequest\\" | \\"TransferMoney\\" | \\"AccountChargeRequest\\" | \\"ServiceBill\\" | \\"ServiceMobileCharge\\" | \\"POS\\" | \\"ShareAndBlockRequest\\" | \\"ShareRequest\\" | \\"Settlement\\" | \\"GroupTransferMoney\\" | \\"ShareAndUnblock\\" | \\"Refund\\" | \\"PayCommand\\" | \\"Gift\\" | \\"TaxiFairPayment\\" | \\"HitoBitFee\\",configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getAccessUserWalletIdLogicalAction.key,userWalletId,logicalAction,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getAccessUserWalletIdLogicalAction(
+                   userWalletId,logicalAction,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetAccessUserWalletIdLogicalAction.prefetch = (
+            client: QueryClient,
+            userWalletId: number,logicalAction: \\"EpayRequest\\" | \\"TransferMoney\\" | \\"AccountChargeRequest\\" | \\"ServiceBill\\" | \\"ServiceMobileCharge\\" | \\"POS\\" | \\"ShareAndBlockRequest\\" | \\"ShareRequest\\" | \\"Settlement\\" | \\"GroupTransferMoney\\" | \\"ShareAndUnblock\\" | \\"Refund\\" | \\"PayCommand\\" | \\"Gift\\" | \\"TaxiFairPayment\\" | \\"HitoBitFee\\",options?:SwaggerTypescriptUseQueryOptions<boolean>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetAccessUserWalletIdLogicalAction.info( userWalletId,logicalAction,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get available banks
+ */
+export const useGetBank = (
+           options?:SwaggerTypescriptUseQueryOptions<BankApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBank.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBank.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBank.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getBank(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetBank.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<BankApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBank.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get Business categories
+ */
+export const useGetBusinessUserCategory = (
+           options?:SwaggerTypescriptUseQueryOptions<BusinessCategoryApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBusinessUserCategory.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBusinessUserCategory.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBusinessUserCategory.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getBusinessUserCategory(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetBusinessUserCategory.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<BusinessCategoryApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBusinessUserCategory.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the connections
+[Feature just allowed for the business users]
+ */
+export const useGetBusinessUserConnection = (
+           queryParams?: GetBusinessUserConnectionQueryParams,options?:SwaggerTypescriptUseQueryOptions<SubUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBusinessUserConnection.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBusinessUserConnection.info = (queryParams?: GetBusinessUserConnectionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBusinessUserConnection.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getBusinessUserConnection(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetBusinessUserConnection.prefetch = (
+            client: QueryClient,
+            queryParams?: GetBusinessUserConnectionQueryParams,options?:SwaggerTypescriptUseQueryOptions<SubUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBusinessUserConnection.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get active connections ordered by Transactions count
+[Feature just allowed for the business users]
+ */
+export const useGetBusinessUserConnectionActive = (
+           queryParams?: GetBusinessUserConnectionActiveQueryParams,options?:SwaggerTypescriptUseQueryOptions<SubUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBusinessUserConnectionActive.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBusinessUserConnectionActive.info = (queryParams?: GetBusinessUserConnectionActiveQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBusinessUserConnectionActive.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getBusinessUserConnectionActive(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetBusinessUserConnectionActive.prefetch = (
+            client: QueryClient,
+            queryParams?: GetBusinessUserConnectionActiveQueryParams,options?:SwaggerTypescriptUseQueryOptions<SubUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBusinessUserConnectionActive.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the connection amounts report
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const useGetBusinessUserConnectionConnectionIdActivity = (
+           
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,options?:SwaggerTypescriptUseQueryOptions< & (SubUserActivityApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBusinessUserConnectionConnectionIdActivity.info( connectionId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBusinessUserConnectionConnectionIdActivity.info = (
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBusinessUserConnectionConnectionIdActivity.key,connectionId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getBusinessUserConnectionConnectionIdActivity(
+                   connectionId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetBusinessUserConnectionConnectionIdActivity.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,options?:SwaggerTypescriptUseQueryOptions< & (SubUserActivityApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBusinessUserConnectionConnectionIdActivity.info( connectionId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetBusinessUserConnectionConnectionIdEpay = (
+           connectionId: number,queryParams?: GetBusinessUserConnectionConnectionIdEpayQueryParams,options?:SwaggerTypescriptUseQueryOptions<EpayRequestApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBusinessUserConnectionConnectionIdEpay.info( connectionId,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBusinessUserConnectionConnectionIdEpay.info = (connectionId: number,queryParams?: GetBusinessUserConnectionConnectionIdEpayQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBusinessUserConnectionConnectionIdEpay.key,connectionId,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getBusinessUserConnectionConnectionIdEpay(
+                   connectionId,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetBusinessUserConnectionConnectionIdEpay.prefetch = (
+            client: QueryClient,
+            connectionId: number,queryParams?: GetBusinessUserConnectionConnectionIdEpayQueryParams,options?:SwaggerTypescriptUseQueryOptions<EpayRequestApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBusinessUserConnectionConnectionIdEpay.info( connectionId,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get sub user permissions for accounts
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const useGetBusinessUserConnectionConnectionIdPermission = (
+           
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,options?:SwaggerTypescriptUseQueryOptions<SubUserPermissionApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBusinessUserConnectionConnectionIdPermission.info( connectionId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBusinessUserConnectionConnectionIdPermission.info = (
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBusinessUserConnectionConnectionIdPermission.key,connectionId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getBusinessUserConnectionConnectionIdPermission(
+                   connectionId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetBusinessUserConnectionConnectionIdPermission.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,options?:SwaggerTypescriptUseQueryOptions<SubUserPermissionApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBusinessUserConnectionConnectionIdPermission.info( connectionId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequest = (
+           queryParams?: GetEpayRequestQueryParams,options?:SwaggerTypescriptUseQueryOptions<EpayRequestApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequest.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequest.info = (queryParams?: GetEpayRequestQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequest.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequest(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequest.prefetch = (
+            client: QueryClient,
+            queryParams?: GetEpayRequestQueryParams,options?:SwaggerTypescriptUseQueryOptions<EpayRequestApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequest.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestAudiencesRecent = (
+           options?:SwaggerTypescriptUseQueryOptions<ContactApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestAudiencesRecent.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestAudiencesRecent.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestAudiencesRecent.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestAudiencesRecent(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestAudiencesRecent.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<ContactApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestAudiencesRecent.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestCount = (
+           queryParams?: GetEpayRequestCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestCount.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestCount.info = (queryParams?: GetEpayRequestCountQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestCount.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestCount(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestCount.prefetch = (
+            client: QueryClient,
+            queryParams?: GetEpayRequestCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestCount.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestEpayTokenDetail = (
+           epayToken: string,options?:SwaggerTypescriptUseQueryOptions< & (EpayRequestPublicInfoApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestEpayTokenDetail.info( epayToken,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestEpayTokenDetail.info = (epayToken: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestEpayTokenDetail.key,epayToken,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestEpayTokenDetail(
+                   epayToken,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestEpayTokenDetail.prefetch = (
+            client: QueryClient,
+            epayToken: string,options?:SwaggerTypescriptUseQueryOptions< & (EpayRequestPublicInfoApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestEpayTokenDetail.info( epayToken,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get QR code image file for epay request
+ */
+export const useGetEpayRequestEpayTokenQrcode = (
+           
+/**
+ * 
+ * epay request token
+ */
+epayToken: string,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestEpayTokenQrcode.info( epayToken,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestEpayTokenQrcode.info = (
+/**
+ * 
+ * epay request token
+ */
+epayToken: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestEpayTokenQrcode.key,epayToken,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestEpayTokenQrcode(
+                   epayToken,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestEpayTokenQrcode.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * epay request token
+ */
+epayToken: string,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestEpayTokenQrcode.info( epayToken,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestExcel = (
+           queryParams?: GetEpayRequestExcelQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestExcel.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestExcel.info = (queryParams?: GetEpayRequestExcelQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestExcel.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestExcel(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestExcel.prefetch = (
+            client: QueryClient,
+            queryParams?: GetEpayRequestExcelQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestExcel.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get pay requests that the user is one of its audiences.
+[Feature is not allowed for sub users]
+[Needs secure login]
+ */
+export const useGetEpayRequestForMe = (
+           queryParams?: GetEpayRequestForMeQueryParams,options?:SwaggerTypescriptUseQueryOptions<EpayRequestForUserQuery[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestForMe.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestForMe.info = (queryParams?: GetEpayRequestForMeQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestForMe.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestForMe(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestForMe.prefetch = (
+            client: QueryClient,
+            queryParams?: GetEpayRequestForMeQueryParams,options?:SwaggerTypescriptUseQueryOptions<EpayRequestForUserQuery[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestForMe.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestForMeCount = (
+           queryParams?: GetEpayRequestForMeCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestForMeCount.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestForMeCount.info = (queryParams?: GetEpayRequestForMeCountQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestForMeCount.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestForMeCount(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestForMeCount.prefetch = (
+            client: QueryClient,
+            queryParams?: GetEpayRequestForMeCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestForMeCount.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestForMeReport = (
+           queryParams?: GetEpayRequestForMeReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReportApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestForMeReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestForMeReport.info = (queryParams?: GetEpayRequestForMeReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestForMeReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestForMeReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestForMeReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetEpayRequestForMeReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReportApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestForMeReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * [Deprecated, use 'account/{accountNumber}/qrcode' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetEpayRequestPosQrAccountNumber = (
+           accountNumber: string,queryParams?: GetEpayRequestPosQrAccountNumberQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestPosQrAccountNumber.info( accountNumber,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestPosQrAccountNumber.info = (accountNumber: string,queryParams?: GetEpayRequestPosQrAccountNumberQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestPosQrAccountNumber.key,accountNumber,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestPosQrAccountNumber(
+                   accountNumber,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestPosQrAccountNumber.prefetch = (
+            client: QueryClient,
+            accountNumber: string,queryParams?: GetEpayRequestPosQrAccountNumberQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestPosQrAccountNumber.info( accountNumber,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestReport = (
+           queryParams?: GetEpayRequestReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReportApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestReport.info = (queryParams?: GetEpayRequestReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetEpayRequestReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReportApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get comission amount for epay request amount
+ */
+export const useGetEpayRequestUserWalletIdCommission = (
+           userWalletId: number,queryParams?: GetEpayRequestUserWalletIdCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestUserWalletIdCommission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestUserWalletIdCommission.info = (userWalletId: number,queryParams?: GetEpayRequestUserWalletIdCommissionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestUserWalletIdCommission.key,userWalletId,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestUserWalletIdCommission(
+                   userWalletId,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestUserWalletIdCommission.prefetch = (
+            client: QueryClient,
+            userWalletId: number,queryParams?: GetEpayRequestUserWalletIdCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestUserWalletIdCommission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestUserWalletIdCreators = (
+           userWalletId: number,options?:SwaggerTypescriptUseQueryOptions<UserMinimalDto[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestUserWalletIdCreators.info( userWalletId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestUserWalletIdCreators.info = (userWalletId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestUserWalletIdCreators.key,userWalletId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestUserWalletIdCreators(
+                   userWalletId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestUserWalletIdCreators.prefetch = (
+            client: QueryClient,
+            userWalletId: number,options?:SwaggerTypescriptUseQueryOptions<UserMinimalDto[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestUserWalletIdCreators.info( userWalletId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetError = (
+           options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetError.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetError.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getError.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getError(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetError.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetError.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetErrorLocal = (
+           options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetErrorLocal.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetErrorLocal.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getErrorLocal.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getErrorLocal(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetErrorLocal.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetErrorLocal.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetErrorStatusCode = (
+           code: number,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetErrorStatusCode.info( code,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetErrorStatusCode.info = (code: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getErrorStatusCode.key,code,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getErrorStatusCode(
+                   code,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetErrorStatusCode.prefetch = (
+            client: QueryClient,
+            code: number,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetErrorStatusCode.info( code,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Download a file.
+ */
+export const useGetFileFileGuid = (
+           
+/**
+ * 
+ * file unique id
+ */
+fileGuid: string,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetFileFileGuid.info( fileGuid,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetFileFileGuid.info = (
+/**
+ * 
+ * file unique id
+ */
+fileGuid: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getFileFileGuid.key,fileGuid,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getFileFileGuid(
+                   fileGuid,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetFileFileGuid.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * file unique id
+ */
+fileGuid: string,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetFileFileGuid.info( fileGuid,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetGroupTransferCommission = (
+           queryParams?: GetGroupTransferCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetGroupTransferCommission.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetGroupTransferCommission.info = (queryParams?: GetGroupTransferCommissionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getGroupTransferCommission.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getGroupTransferCommission(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetGroupTransferCommission.prefetch = (
+            client: QueryClient,
+            queryParams?: GetGroupTransferCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetGroupTransferCommission.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get detailed driver,taxi and fair amount information
+ */
+export const useGetIntegration = (
+           queryParams?: GetIntegrationQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (DriverInfoResult)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetIntegration.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetIntegration.info = (queryParams?: GetIntegrationQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getIntegration.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getIntegration(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetIntegration.prefetch = (
+            client: QueryClient,
+            queryParams?: GetIntegrationQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (DriverInfoResult)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetIntegration.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetKpi = (
+           queryParams?: GetKpiQueryParams,options?:SwaggerTypescriptUseQueryOptions<KpiResult[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetKpi.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetKpi.info = (queryParams?: GetKpiQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getKpi.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getKpi(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetKpi.prefetch = (
+            client: QueryClient,
+            queryParams?: GetKpiQueryParams,options?:SwaggerTypescriptUseQueryOptions<KpiResult[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetKpi.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetKpiCurrent = (
+           queryParams?: GetKpiCurrentQueryParams,options?:SwaggerTypescriptUseQueryOptions<KpiResult[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetKpiCurrent.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetKpiCurrent.info = (queryParams?: GetKpiCurrentQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getKpiCurrent.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getKpiCurrent(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetKpiCurrent.prefetch = (
+            client: QueryClient,
+            queryParams?: GetKpiCurrentQueryParams,options?:SwaggerTypescriptUseQueryOptions<KpiResult[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetKpiCurrent.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetKpiLast = (
+           queryParams?: GetKpiLastQueryParams,options?:SwaggerTypescriptUseQueryOptions<KpiResult[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetKpiLast.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetKpiLast.info = (queryParams?: GetKpiLastQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getKpiLast.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getKpiLast(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetKpiLast.prefetch = (
+            client: QueryClient,
+            queryParams?: GetKpiLastQueryParams,options?:SwaggerTypescriptUseQueryOptions<KpiResult[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetKpiLast.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get all Important Actions of current user.
+ */
+export const useGetNotificationIa = (
+           options?:SwaggerTypescriptUseQueryOptions<ImportantActionApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetNotificationIa.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetNotificationIa.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getNotificationIa.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getNotificationIa(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetNotificationIa.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<ImportantActionApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetNotificationIa.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get Notifications of current user.
+Maximum 99 items will be returned.
+ */
+export const useGetNotificationNotif = (
+           options?:SwaggerTypescriptUseQueryOptions<NotificationApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetNotificationNotif.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetNotificationNotif.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getNotificationNotif.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getNotificationNotif(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetNotificationNotif.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<NotificationApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetNotificationNotif.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetNotificationUnread = (
+           queryParams?: GetNotificationUnreadQueryParams,options?:SwaggerTypescriptUseQueryOptions<UnreadNotificationCountApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetNotificationUnread.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetNotificationUnread.info = (queryParams?: GetNotificationUnreadQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getNotificationUnread.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getNotificationUnread(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetNotificationUnread.prefetch = (
+            client: QueryClient,
+            queryParams?: GetNotificationUnreadQueryParams,options?:SwaggerTypescriptUseQueryOptions<UnreadNotificationCountApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetNotificationUnread.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get epay request detail
+ */
+export const useGetPosAccountNumber = (
+           
+/**
+ * 
+ * Account Number
+ */
+accountNumber: string,queryParams?: GetPosAccountNumberQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (PosLandingPageApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetPosAccountNumber.info( accountNumber,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetPosAccountNumber.info = (
+/**
+ * 
+ * Account Number
+ */
+accountNumber: string,queryParams?: GetPosAccountNumberQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getPosAccountNumber.key,accountNumber,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getPosAccountNumber(
+                   accountNumber,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetPosAccountNumber.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * Account Number
+ */
+accountNumber: string,queryParams?: GetPosAccountNumberQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (PosLandingPageApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetPosAccountNumber.info( accountNumber,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get bank receipt by EPayRequest token
+[For anonymous users]
+[Deprecated, use 'receipt/bank/{epayTryId}' and 'receipt/bank/{epayTryId}' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetReceiptEpayToken = (
+           
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,options?:SwaggerTypescriptUseQueryOptions< & (BankReceiptApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetReceiptEpayToken.info( epayToken,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetReceiptEpayToken.info = (
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getReceiptEpayToken.key,epayToken,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getReceiptEpayToken(
+                   epayToken,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetReceiptEpayToken.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,options?:SwaggerTypescriptUseQueryOptions< & (BankReceiptApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetReceiptEpayToken.info( epayToken,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get wallet receipt by EPayRequest token
+[For anonymous users]
+ */
+export const useGetReceiptWalletEpayToken = (
+           
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,options?:SwaggerTypescriptUseQueryOptions< & (WalletReceiptApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetReceiptWalletEpayToken.info( epayToken,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetReceiptWalletEpayToken.info = (
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getReceiptWalletEpayToken.key,epayToken,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getReceiptWalletEpayToken(
+                   epayToken,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetReceiptWalletEpayToken.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,options?:SwaggerTypescriptUseQueryOptions< & (WalletReceiptApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetReceiptWalletEpayToken.info( epayToken,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the Resellership info of current Reseller user
+[Feature just allowed for Resellers]
+ */
+export const useGetResellerUser = (
+           options?:SwaggerTypescriptUseQueryOptions< & (ResellerApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUser.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUser.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUser.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getResellerUser(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUser.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions< & (ResellerApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUser.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the time-based report of commissions paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardCommissionReport = (
+           queryParams?: GetResellerUserDashboardCommissionReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfDecimal[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardCommissionReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardCommissionReport.info = (queryParams?: GetResellerUserDashboardCommissionReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardCommissionReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardCommissionReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardCommissionReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardCommissionReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfDecimal[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardCommissionReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get sum of all commissions paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardCommissionSum = (
+           queryParams?: GetResellerUserDashboardCommissionSumQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardCommissionSum.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardCommissionSum.info = (queryParams?: GetResellerUserDashboardCommissionSumQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardCommissionSum.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardCommissionSum(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardCommissionSum.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardCommissionSumQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardCommissionSum.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get count of all users reselled by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardIntroducedCount = (
+           queryParams?: GetResellerUserDashboardIntroducedCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardIntroducedCount.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardIntroducedCount.info = (queryParams?: GetResellerUserDashboardIntroducedCountQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardIntroducedCount.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardIntroducedCount(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardIntroducedCount.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardIntroducedCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardIntroducedCount.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get time-based report of users reselled by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardIntroducedReport = (
+           queryParams?: GetResellerUserDashboardIntroducedReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardIntroducedReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardIntroducedReport.info = (queryParams?: GetResellerUserDashboardIntroducedReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardIntroducedReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardIntroducedReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardIntroducedReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardIntroducedReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardIntroducedReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get count of all links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardLinksCount = (
+           queryParams?: GetResellerUserDashboardLinksCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardLinksCount.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardLinksCount.info = (queryParams?: GetResellerUserDashboardLinksCountQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardLinksCount.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardLinksCount(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardLinksCount.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardLinksCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardLinksCount.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get count of all paid links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardLinksPaidCount = (
+           queryParams?: GetResellerUserDashboardLinksPaidCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardLinksPaidCount.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardLinksPaidCount.info = (queryParams?: GetResellerUserDashboardLinksPaidCountQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardLinksPaidCount.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardLinksPaidCount(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardLinksPaidCount.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardLinksPaidCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardLinksPaidCount.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get time-based report of paid links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardLinksPaidReport = (
+           queryParams?: GetResellerUserDashboardLinksPaidReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardLinksPaidReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardLinksPaidReport.info = (queryParams?: GetResellerUserDashboardLinksPaidReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardLinksPaidReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardLinksPaidReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardLinksPaidReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardLinksPaidReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardLinksPaidReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get time-based report of links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardLinksReport = (
+           queryParams?: GetResellerUserDashboardLinksReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardLinksReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardLinksReport.info = (queryParams?: GetResellerUserDashboardLinksReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardLinksReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardLinksReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardLinksReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardLinksReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardLinksReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get count of all commission transactions, paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardTransactionsCount = (
+           queryParams?: GetResellerUserDashboardTransactionsCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardTransactionsCount.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardTransactionsCount.info = (queryParams?: GetResellerUserDashboardTransactionsCountQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardTransactionsCount.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardTransactionsCount(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardTransactionsCount.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardTransactionsCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardTransactionsCount.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get time-based report of commission transactions, paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardTransactionsReport = (
+           queryParams?: GetResellerUserDashboardTransactionsReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardTransactionsReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardTransactionsReport.info = (queryParams?: GetResellerUserDashboardTransactionsReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardTransactionsReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardTransactionsReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardTransactionsReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardTransactionsReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardTransactionsReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the Users Introduced by current Reseller user
+[Feature just allowed for Resellers]
+ */
+export const useGetResellerUserIntroduced = (
+           queryParams?: GetResellerUserIntroducedQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReselledUserApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserIntroduced.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserIntroduced.info = (queryParams?: GetResellerUserIntroducedQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserIntroduced.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserIntroduced(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserIntroduced.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserIntroducedQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReselledUserApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserIntroduced.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get filter data items to populate DropDowns
+[Feature just allowed for Resellers]
+ */
+export const useGetResellerUserIntroducedFilterData = (
+           options?:SwaggerTypescriptUseQueryOptions< & (ReselledUserFilterData)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserIntroducedFilterData.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserIntroducedFilterData.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserIntroducedFilterData.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserIntroducedFilterData(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserIntroducedFilterData.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions< & (ReselledUserFilterData)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserIntroducedFilterData.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the User activity
+[Feature just allowed for Resellers]
+ */
+export const useGetResellerUserIntroducedUserIdActivity = (
+           userId: string,options?:SwaggerTypescriptUseQueryOptions< & (ReselledUserActivityApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserIntroducedUserIdActivity.info( userId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserIntroducedUserIdActivity.info = (userId: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserIntroducedUserIdActivity.key,userId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserIntroducedUserIdActivity(
+                   userId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserIntroducedUserIdActivity.prefetch = (
+            client: QueryClient,
+            userId: string,options?:SwaggerTypescriptUseQueryOptions< & (ReselledUserActivityApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserIntroducedUserIdActivity.info( userId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the SubDomain of current Reseller user
+[Feature just allowed for Resellers]
+ */
+export const useGetSubDomain = (
+           options?:SwaggerTypescriptUseQueryOptions< & (SubDomainApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetSubDomain.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetSubDomain.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getSubDomain.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getSubDomain(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetSubDomain.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions< & (SubDomainApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetSubDomain.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get info of a SubDomain by it's address.
+ */
+export const useGetSubDomainSubDomainAddress = (
+           
+/**
+ * 
+ * The SubDomain part of the url.
+            
+ */
+subDomainAddress: string,headerParams?: {
+/**
+ * 
+ * - Format: guid
+ */
+\\"clientId\\": string;},options?:SwaggerTypescriptUseQueryOptions< & (SubDomainApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetSubDomainSubDomainAddress.info( subDomainAddress,
+          
+          
+          headerParams, configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetSubDomainSubDomainAddress.info = (
+/**
+ * 
+ * The SubDomain part of the url.
+            
+ */
+subDomainAddress: string,headerParams?: {
+/**
+ * 
+ * - Format: guid
+ */
+\\"clientId\\": string;},configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getSubDomainSubDomainAddress.key,subDomainAddress,
+            
+            
+            headerParams,] as QueryKey,
+                fun: () =>
+                getSubDomainSubDomainAddress(
+                   subDomainAddress,
+          
+          
+          headerParams,
+                  configOverride
+                ),
+              };
+            };useGetSubDomainSubDomainAddress.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * The SubDomain part of the url.
+            
+ */
+subDomainAddress: string,headerParams?: {
+/**
+ * 
+ * - Format: guid
+ */
+\\"clientId\\": string;},options?:SwaggerTypescriptUseQueryOptions< & (SubDomainApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetSubDomainSubDomainAddress.info( subDomainAddress,
+          
+          
+          headerParams, configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the connections
+[Feature just allowed for SubUsers]
+[Deprecated. use 'user/connection' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetSubUserConnection = (
+           options?:SwaggerTypescriptUseQueryOptions<BusinessUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetSubUserConnection.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetSubUserConnection.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getSubUserConnection.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getSubUserConnection(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetSubUserConnection.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<BusinessUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetSubUserConnection.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetTransaction = (
+           queryParams?: GetTransactionQueryParams,options?:SwaggerTypescriptUseQueryOptions<TransactionApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransaction.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransaction.info = (queryParams?: GetTransactionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransaction.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getTransaction(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetTransaction.prefetch = (
+            client: QueryClient,
+            queryParams?: GetTransactionQueryParams,options?:SwaggerTypescriptUseQueryOptions<TransactionApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransaction.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetTransactionExcel = (
+           queryParams?: GetTransactionExcelQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransactionExcel.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransactionExcel.info = (queryParams?: GetTransactionExcelQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransactionExcel.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getTransactionExcel(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetTransactionExcel.prefetch = (
+            client: QueryClient,
+            queryParams?: GetTransactionExcelQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransactionExcel.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetTransactionReport = (
+           queryParams?: GetTransactionReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReportApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransactionReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransactionReport.info = (queryParams?: GetTransactionReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransactionReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getTransactionReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetTransactionReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetTransactionReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReportApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransactionReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetTransactionReportAll = (
+           queryParams?: GetTransactionReportAllQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AllTransactionsReportApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransactionReportAll.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransactionReportAll.info = (queryParams?: GetTransactionReportAllQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransactionReportAll.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getTransactionReportAll(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetTransactionReportAll.prefetch = (
+            client: QueryClient,
+            queryParams?: GetTransactionReportAllQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AllTransactionsReportApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransactionReportAll.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get recent money transfers
+ */
+export const useGetTransferRecent = (
+           queryParams?: GetTransferRecentQueryParams,options?:SwaggerTypescriptUseQueryOptions<TransferMoneyApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransferRecent.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransferRecent.info = (queryParams?: GetTransferRecentQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransferRecent.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getTransferRecent(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetTransferRecent.prefetch = (
+            client: QueryClient,
+            queryParams?: GetTransferRecentQueryParams,options?:SwaggerTypescriptUseQueryOptions<TransferMoneyApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransferRecent.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetTransferSearch = (
+           queryParams?: GetTransferSearchQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AccountInfoApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransferSearch.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransferSearch.info = (queryParams?: GetTransferSearchQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransferSearch.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getTransferSearch(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetTransferSearch.prefetch = (
+            client: QueryClient,
+            queryParams?: GetTransferSearchQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AccountInfoApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransferSearch.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get commission amount for transfer money amount
+ */
+export const useGetTransferUserWalletIdCommission = (
+           userWalletId: number,queryParams?: GetTransferUserWalletIdCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransferUserWalletIdCommission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransferUserWalletIdCommission.info = (userWalletId: number,queryParams?: GetTransferUserWalletIdCommissionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransferUserWalletIdCommission.key,userWalletId,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getTransferUserWalletIdCommission(
+                   userWalletId,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetTransferUserWalletIdCommission.prefetch = (
+            client: QueryClient,
+            userWalletId: number,queryParams?: GetTransferUserWalletIdCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransferUserWalletIdCommission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get [normal/sub/business] user profile detail
+ */
+export const useGetUser = (
+           options?:SwaggerTypescriptUseQueryOptions< & (UserDetailQuery)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUser.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUser.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUser.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUser(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUser.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions< & (UserDetailQuery)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUser.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get user banks
+[Feature is not allowed for sub users.]
+ */
+export const useGetUserBank = (
+           options?:SwaggerTypescriptUseQueryOptions<UserBankApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserBank.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserBank.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserBank.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserBank(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserBank.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<UserBankApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserBank.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get available user banks
+[Feature is not allowed for sub users.]
+ */
+export const useGetUserBankReady = (
+           options?:SwaggerTypescriptUseQueryOptions<UserBankApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserBankReady.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserBankReady.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserBankReady.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserBankReady(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserBankReady.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<UserBankApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserBankReady.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the connections [Feature is allowed for normal users noly]
+ */
+export const useGetUserConnection = (
+           options?:SwaggerTypescriptUseQueryOptions<BusinessUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserConnection.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserConnection.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserConnection.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserConnection(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserConnection.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<BusinessUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserConnection.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetUserContactInput = (
+           input: string,options?:SwaggerTypescriptUseQueryOptions< & (ContactApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserContactInput.info( input,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserContactInput.info = (input: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserContactInput.key,input,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserContactInput(
+                   input,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserContactInput.prefetch = (
+            client: QueryClient,
+            input: string,options?:SwaggerTypescriptUseQueryOptions< & (ContactApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserContactInput.info( input,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get last national id verification request [Feature is not allowed for sub users]
+ */
+export const useGetUserIdentityRequest = (
+           options?:SwaggerTypescriptUseQueryOptions< & (UserIdentityRequestQuery)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserIdentityRequest.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserIdentityRequest.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserIdentityRequest.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserIdentityRequest(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserIdentityRequest.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions< & (UserIdentityRequestQuery)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserIdentityRequest.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get business user invitations for me [Feature is not allowed for sub users]
+ */
+export const useGetUserInvitation = (
+           options?:SwaggerTypescriptUseQueryOptions<SubUserInvitationApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserInvitation.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserInvitation.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserInvitation.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserInvitation(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserInvitation.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<SubUserInvitationApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserInvitation.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get business user invitations for me [Feature is not allowed for sub users]
+ */
+export const useGetUserInvitationInvitationToken = (
+           invitationToken: string,options?:SwaggerTypescriptUseQueryOptions< & (SubUserInvitationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserInvitationInvitationToken.info( invitationToken,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserInvitationInvitationToken.info = (invitationToken: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserInvitationInvitationToken.key,invitationToken,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserInvitationInvitationToken(
+                   invitationToken,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserInvitationInvitationToken.prefetch = (
+            client: QueryClient,
+            invitationToken: string,options?:SwaggerTypescriptUseQueryOptions< & (SubUserInvitationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserInvitationInvitationToken.info( invitationToken,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get user profile summary
+ */
+export const useGetUserMe = (
+           options?:SwaggerTypescriptUseQueryOptions< & (UserMeQuery)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserMe.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserMe.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserMe.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserMe(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserMe.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions< & (UserMeQuery)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserMe.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetUserPlugin = (
+           options?:SwaggerTypescriptUseQueryOptions<UserPluginDetailApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserPlugin.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserPlugin.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserPlugin.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserPlugin(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserPlugin.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<UserPluginDetailApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserPlugin.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get Last Request for upgrade account to the business [Feature is allowed for normal users only]
+ */
+export const useGetUserUpgradeToBusinessRequest = (
+           options?:SwaggerTypescriptUseQueryOptions< & (UpgradeToBusinessApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserUpgradeToBusinessRequest.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserUpgradeToBusinessRequest.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserUpgradeToBusinessRequest.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserUpgradeToBusinessRequest(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserUpgradeToBusinessRequest.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions< & (UpgradeToBusinessApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserUpgradeToBusinessRequest.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetUserWallet = (
+           options?:SwaggerTypescriptUseQueryOptions<WalletDisplayApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWallet.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWallet.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWallet.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserWallet(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWallet.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<WalletDisplayApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWallet.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetUserWalletAccountNumberQrcode = (
+           accountNumber: string,queryParams?: GetUserWalletAccountNumberQrcodeQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletAccountNumberQrcode.info( accountNumber,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletAccountNumberQrcode.info = (accountNumber: string,queryParams?: GetUserWalletAccountNumberQrcodeQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletAccountNumberQrcode.key,accountNumber,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletAccountNumberQrcode(
+                   accountNumber,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletAccountNumberQrcode.prefetch = (
+            client: QueryClient,
+            accountNumber: string,queryParams?: GetUserWalletAccountNumberQrcodeQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletAccountNumberQrcode.info( accountNumber,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetUserWalletSearch = (
+           queryParams?: GetUserWalletSearchQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AccountInfoApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletSearch.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletSearch.info = (queryParams?: GetUserWalletSearchQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletSearch.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletSearch(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletSearch.prefetch = (
+            client: QueryClient,
+            queryParams?: GetUserWalletSearchQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AccountInfoApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletSearch.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get user account balance
+ */
+export const useGetUserWalletUserWalletIdBalance = (
+           userWalletId: number,options?:SwaggerTypescriptUseQueryOptions< & (AccountBalanceApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletUserWalletIdBalance.info( userWalletId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletUserWalletIdBalance.info = (userWalletId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletUserWalletIdBalance.key,userWalletId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletUserWalletIdBalance(
+                   userWalletId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletUserWalletIdBalance.prefetch = (
+            client: QueryClient,
+            userWalletId: number,options?:SwaggerTypescriptUseQueryOptions< & (AccountBalanceApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletUserWalletIdBalance.info( userWalletId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetUserWalletUserWalletIdEpayRequestComission = (
+           userWalletId: number,queryParams?: GetUserWalletUserWalletIdEpayRequestComissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletUserWalletIdEpayRequestComission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletUserWalletIdEpayRequestComission.info = (userWalletId: number,queryParams?: GetUserWalletUserWalletIdEpayRequestComissionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletUserWalletIdEpayRequestComission.key,userWalletId,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletUserWalletIdEpayRequestComission(
+                   userWalletId,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletUserWalletIdEpayRequestComission.prefetch = (
+            client: QueryClient,
+            userWalletId: number,queryParams?: GetUserWalletUserWalletIdEpayRequestComissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletUserWalletIdEpayRequestComission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetUserWalletUserWalletIdPermittedsubusers = (
+           userWalletId: number,options?:SwaggerTypescriptUseQueryOptions<AccountPermittedSubUserQuery[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletUserWalletIdPermittedsubusers.info( userWalletId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletUserWalletIdPermittedsubusers.info = (userWalletId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletUserWalletIdPermittedsubusers.key,userWalletId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletUserWalletIdPermittedsubusers(
+                   userWalletId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletUserWalletIdPermittedsubusers.prefetch = (
+            client: QueryClient,
+            userWalletId: number,options?:SwaggerTypescriptUseQueryOptions<AccountPermittedSubUserQuery[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletUserWalletIdPermittedsubusers.info( userWalletId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetUserWalletUserWalletIdSettlementRequestComission = (
+           userWalletId: number,queryParams?: GetUserWalletUserWalletIdSettlementRequestComissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletUserWalletIdSettlementRequestComission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletUserWalletIdSettlementRequestComission.info = (userWalletId: number,queryParams?: GetUserWalletUserWalletIdSettlementRequestComissionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletUserWalletIdSettlementRequestComission.key,userWalletId,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletUserWalletIdSettlementRequestComission(
+                   userWalletId,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletUserWalletIdSettlementRequestComission.prefetch = (
+            client: QueryClient,
+            userWalletId: number,queryParams?: GetUserWalletUserWalletIdSettlementRequestComissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletUserWalletIdSettlementRequestComission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetUserWalletUserWalletIdTransferMoneyCommission = (
+           userWalletId: number,queryParams?: GetUserWalletUserWalletIdTransferMoneyCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletUserWalletIdTransferMoneyCommission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletUserWalletIdTransferMoneyCommission.info = (userWalletId: number,queryParams?: GetUserWalletUserWalletIdTransferMoneyCommissionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletUserWalletIdTransferMoneyCommission.key,userWalletId,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletUserWalletIdTransferMoneyCommission(
+                   userWalletId,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletUserWalletIdTransferMoneyCommission.prefetch = (
+            client: QueryClient,
+            userWalletId: number,queryParams?: GetUserWalletUserWalletIdTransferMoneyCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletUserWalletIdTransferMoneyCommission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get user work spaces
+ */
+export const useGetUserWorkspace = (
+           options?:SwaggerTypescriptUseQueryOptions<UserWorkspaceQuery[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWorkspace.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWorkspace.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWorkspace.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserWorkspace(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWorkspace.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<UserWorkspaceQuery[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWorkspace.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }"
+`;
+
+exports[`only includes get methods does not ends with Id generate type 1`] = `
+"
+//@ts-nocheck
+/**
+* AUTO_GENERATED Do not change this file directly, use config.ts file instead
+*
+* @version 6
+*/
+
+        
+        export interface AccountBalanceApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"realBalance\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"totalBalance\\": number;}
+        
+        
+        export interface AccountCreationApiModel {\\"automaticSettlement\\"?: boolean;\\"getComissionFromPayer\\"?: boolean;\\"isActive\\"?: boolean;\\"title\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"userBankId\\"?: number;}
+        
+        
+        export interface AccountInfoApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"accountOwnerAvatarUrl\\"?: string;\\"accountOwnerTitle\\"?: string;}
+        
+        
+        export interface AccountPermittedSubUserQuery {
+/**
+ * 
+ * - Format: int64
+ */
+\\"connectionId\\": number;\\"connectionStatus\\": SubUserConnectionStatus;
+/**
+ * 
+ * [Deprecated, use 'ConnectionStatus' instead]
+ * @deprecated Use 'ConnectionStatus' instead.
+ */
+\\"subUserConnectionStatus\\":  & (SubUserConnectionStatus);
+/**
+ * 
+ * - Format: guid
+ */
+\\"subuserId\\": string;\\"subuserStatus\\": SubuserStatus;\\"connectDate\\"?: string;\\"connectionStatusDisplay\\"?: string;\\"disconnectDate\\"?: string;\\"subUserAvatarUrl\\"?: string;\\"subUserContact\\"?: string;\\"subUserPositionTitle\\"?: string;\\"subUserTitle\\"?: string;\\"subuserStatusDisplay\\"?: string;}
+        
+        
+        export interface AccountSettingNotificationStatusApiModel {\\"notificationEnabled\\": boolean;}
+        
+        
+        export enum AccountStatus {Block=\\"Block\\",OK=\\"OK\\"}
+        
+        
+        export interface AggregationApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"count\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"sum\\": number;}
+        
+        
+        export interface AllTransactionsReportApiModel {\\"credits\\"?: ReportApiModel[];\\"debits\\"?: ReportApiModel[];}
+        
+        
+        export interface BankApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"id\\": number;\\"logoUrl\\"?: string;\\"name\\"?: string;}
+        
+        
+        export interface BankReceiptApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionAmount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDate\\": string;\\"failed\\": boolean;\\"type\\": EpayRequestType;\\"createDateDisplay\\"?: string;\\"creatorUserAvatarUrl\\"?: string;\\"creatorUserDisplayName\\"?: string;\\"description\\"?: string;\\"failureMessage\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"operationId\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"payerAccountId\\"?: number;\\"payerAccountName\\"?: string;\\"payerAccountNumber\\"?: string;\\"shareUrl\\"?: string;\\"targetAccountNumber\\"?: string;\\"targetAvatarUrl\\"?: string;\\"targetUserDisplayName\\"?: string;\\"typeDisplay\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"voucherId\\"?: number;}
+        
+        
+        export interface BusinessCategoryApiModel {\\"id\\": BusinessType;\\"title\\"?: string;}
+        
+        
+        export enum BusinessShareType {Person=\\"Person\\",PrivateStock=\\"PrivateStock\\",PublicStock=\\"PublicStock\\",Limited=\\"Limited\\",GeneralPartnership=\\"GeneralPartnership\\",Institute=\\"Institute\\",Cooperative=\\"Cooperative\\"}
+        
+        
+        export enum BusinessType {Ads=\\"Ads\\",Investment=\\"Investment\\",Production=\\"Production\\",Trade=\\"Trade\\",Software=\\"Software\\"}
+        
+        
+        export interface BusinessUserConnectionApiModel {
+/**
+ * 
+ * - Format: guid
+ */
+\\"businessId\\": string;\\"status\\": SubUserConnectionStatus;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"subUserConnectionStatus\\":  & (SubUserConnectionStatus);\\"businessAvatarUrl\\"?: string;\\"businessName\\"?: string;\\"connectDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"connectDateTime\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"connectionId\\"?: number;\\"disconnectDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"disconnectDateTime\\"?: string;\\"positionTitle\\"?: string;\\"statusDisplay\\"?: string;}
+        
+        
+        export enum CallbackType {None=\\"None\\",Redirect=\\"Redirect\\",RedirectWithPost=\\"RedirectWithPost\\",Call=\\"Call\\"}
+        
+        
+        export interface ClientPurchaseInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"instituteCode\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"userWalletId\\": number;\\"driverCode\\"?: string;}
+        
+        
+        export enum ComissionType {Percentage=\\"Percentage\\",Fixed=\\"Fixed\\"}
+        
+        
+        export interface CommissionAmountApiModel {
+/**
+ * 
+ * [Deprecated, use 'CommissionAmount' instead]
+ * - Format: decimal
+ * @deprecated Use CommissionAmount instead.
+ */
+\\"comissionAmount\\": number;
+/**
+ * 
+ * کارمزد
+ * - Format: decimal
+ */
+\\"commissionAmount\\": number;
+/**
+ * 
+ * مبلغ اصلی
+ * - Format: decimal
+ */
+\\"requestAmount\\": number;
+/**
+ * 
+ * جمع مبلغ اصلی و کارمزد
+ * - Format: decimal
+ */
+\\"totalAmount\\": number;}
+        
+        
+        export interface CommissionPolicyApiModel {\\"commissionType\\": ComissionType;\\"logicalAction\\": LogicalActionType;\\"commissionTypeDisplay\\"?: string;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"fixedValue\\"?: number;\\"logicalActionDisplay\\"?: string;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"maxValue\\"?: number;
+/**
+ * 
+ * - Format: double
+ */
+\\"percent\\"?: number;\\"title\\"?: string;\\"value\\"?: string;}
+        
+        
+        export interface ContactApiModel {\\"audienceType\\": UserIdentifierType;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"audienceTypeDisplay\\"?: string;\\"contact\\"?: string;\\"fullName\\"?: string;\\"userDisplayName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\"?: string;\\"userProfileImageLink\\"?: string;}
+        
+        
+        export enum DatePart {Minute=\\"Minute\\",Hour=\\"Hour\\",Day=\\"Day\\",Week=\\"Week\\",Month=\\"Month\\",Year=\\"Year\\",All=\\"All\\"}
+        
+        
+        export interface DateReportApiModelOfDecimal {
+/**
+ * 
+ * - Format: int32
+ */
+\\"day\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"key\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"value\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\": number;\\"dayName\\"?: string;\\"label\\"?: string;\\"monthName\\"?: string;}
+        
+        
+        export interface DateReportApiModelOfInteger {
+/**
+ * 
+ * - Format: int32
+ */
+\\"day\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"key\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"value\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\": number;\\"dayName\\"?: string;\\"label\\"?: string;\\"monthName\\"?: string;}
+        
+        
+        export interface DivideEpayRequestServiceInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"expiresAfterDays\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"invoiceDate\\": string;\\"isAutoRedirect\\": boolean;\\"isBlocking\\": boolean;\\"callBackUrl\\"?: string;\\"description\\"?: string;\\"divisions\\"?: DivideEpayRequestShareModel[];\\"invoiceNumber\\"?: string;}
+        
+        
+        export interface DivideEpayRequestShareModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"dividerAmount\\": number;\\"apiKey\\"?: string;\\"invoiceNumber\\"?: string;}
+        
+        
+        export interface DividedEpayRequestCancelInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"dividerAmount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"userAmount\\": number;\\"description\\"?: string;\\"firstName\\"?: string;\\"invoiceNumber\\"?: string;\\"lastName\\"?: string;\\"paymentToken\\"?: string;\\"shebaNo\\"?: string;\\"userApiKey\\"?: string;}
+        
+        
+        export interface DividedEpayRequestCancelResult {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"cancelledAmount\\": number;}
+        
+        
+        export interface DividedEpayRequestUnblockInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"dividerAmount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"userAmount\\": number;\\"description\\"?: string;\\"invoiceNumber\\"?: string;\\"paymentToken\\"?: string;\\"userApiKey\\"?: string;}
+        
+        
+        export interface DividedEpayRequestUnblockResult {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"unblockedAmount\\": number;}
+        
+        
+        export interface DocumentApiModel {\\"contentType\\": DocumentContentType;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDate\\": string;
+/**
+ * 
+ * [Deprecated, use 'ContentType' instead]
+ * @deprecated Use 'ContentType' instead.
+ */
+\\"documentContentType\\":  & (DocumentContentType);
+/**
+ * 
+ * - Format: int64
+ */
+\\"fileSize\\": number;\\"fileType\\": FileTypes;
+/**
+ * 
+ * [Deprecated, use 'FileType' instead]
+ * @deprecated Use 'FileType' instead.
+ */
+\\"fileTypes\\":  & (FileTypes);
+/**
+ * 
+ * - Format: guid
+ */
+\\"uniqueId\\": string;\\"contentTypeDisplay\\"?: string;\\"fileName\\"?: string;\\"fileTypeDisplay\\"?: string;\\"fileUrl\\"?: string;}
+        
+        
+        export enum DocumentContentType {Other=\\"Other\\",UserBankVerification=\\"UserBankVerification\\",IdentityCard=\\"IdentityCard\\",BusinessStatute=\\"BusinessStatute\\",BusinessLatestChangesAnnouncement=\\"BusinessLatestChangesAnnouncement\\",BusinessOwnersIdentityCards=\\"BusinessOwnersIdentityCards\\",BusinessOwnersBirthCertificates=\\"BusinessOwnersBirthCertificates\\"}
+        
+        
+        export interface DocumentInput {\\"documentContentType\\": DocumentContentType;
+/**
+ * 
+ * - Format: guid
+ */
+\\"fileUniqueId\\": string;}
+        
+        
+        export interface DriverInfoResult {\\"barcodType\\": number;\\"barcodTypeDescription\\"?: string;\\"customData\\"?:  & (TaxiInfoOutput);\\"firstName\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"identificationCode\\"?: number;\\"identificationDesc\\"?: string;\\"imageUrl\\"?: string;\\"lastName\\"?: string;\\"nationalCode\\"?: string;\\"price\\"?: TaxiPriceOutput[];}
+        
+        
+        export interface DropDownResultItemOfIdentityStatus {\\"value\\": IdentityStatus;\\"display\\"?: string;}
+        
+        
+        export interface DropDownResultOfIdentityStatus {\\"items\\"?: DropDownResultItemOfIdentityStatus[];}
+        
+        
+        export interface EPayPluginSpecificApiModel {\\"id\\"?: string;\\"persianName\\"?: string;
+/**
+ * 
+ * [Deprecated, don't use this property anymore, it is always null]
+ * @deprecated Don't use this property anymore, it is always null.
+ */
+\\"pluginPropertyId\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'Id' instead]
+ * @deprecated Use 'Id' instead.
+ */
+\\"pluginPropertyName\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'PersianName' instead]
+ * @deprecated Use 'PersianName' instead.
+ */
+\\"pluginPropertyPersianName\\"?: string;\\"value\\"?: string;}
+        
+        
+        export interface EPayRequestAudienceInput {\\"contact\\"?: string;\\"fullName\\"?: string;}
+        
+        
+        export interface EditConnectionInfoInput {\\"position\\"?: string;}
+        
+        
+        export interface EditSubUserPermissionInput {\\"isEnabled\\"?: boolean;\\"subUserPermissionType\\"?:  & (SubUserPermissionType);}
+        
+        
+        export enum EpayRequestActualState {Initiated=\\"Initiated\\",Paid=\\"Paid\\",Cancelled=\\"Cancelled\\",Expired=\\"Expired\\"}
+        
+        
+        export interface EpayRequestApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"epayRequestStatus\\":  & (EpayRequestStatus);
+/**
+ * 
+ * - Format: date-time
+ */
+\\"expireDateTime\\": string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"status\\": EpayRequestActualState;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"assistantDisplayName\\"?: string;\\"assistantPositionTitle\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"assistantUserId\\"?: string;\\"createDate\\"?: string;\\"description\\"?: string;
+/**
+ * 
+ * [Deprecated, don't use EpayRequestAudience]
+ * @deprecated Don't use EpayRequestAudience.
+ */
+\\"epayRequestAudience\\"?: EPayRequestAudienceInput[];\\"expireDate\\"?: string;\\"payDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"payDateTime\\"?: string;\\"payerName\\"?: string;\\"paymentLink\\"?: string;\\"qrCodeLink\\"?: string;\\"statusDisplay\\"?: string;\\"targetDisplayName\\"?: string;\\"userAccountName\\"?: string;}
+        
+        
+        export interface EpayRequestCheckStatusResult {\\"requestStatus\\": EpayRequestStatus;\\"bankReferenceId\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"verifyDate\\"?: string;}
+        
+        
+        export interface EpayRequestDetailApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * [Deprecated, use 'CommissionAmount' instead]
+ * - Format: decimal
+ * @deprecated Use 'CommissionAmount' instead.
+ */
+\\"comissionAmount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionAmount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"epayRequestStatus\\":  & (EpayRequestStatus);
+/**
+ * 
+ * - Format: date-time
+ */
+\\"expireDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'GetCommissionFromPayer' instead]
+ * @deprecated Use 'GetCommissionFromPayer' instead.
+ */
+\\"getComissionByPayer\\": boolean;\\"getCommissionFromPayer\\": boolean;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"status\\": EpayRequestActualState;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"assistantDisplayName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"assistantUserId\\"?: string;\\"audiences\\"?: ContactApiModel[];\\"description\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'Audiences' instead]
+ * @deprecated Use 'Audiences' instead.
+ */
+\\"epayRequestAudience\\"?: ContactApiModel[];
+/**
+ * 
+ * [Deprecated, use 'PluginProperties' instead]
+ * @deprecated Use 'PluginProperties' instead.
+ */
+\\"epayRequestPluginSpecific\\"?: EPayPluginSpecificApiModel[];
+/**
+ * 
+ * - Format: date-time
+ */
+\\"payDateTime\\"?: string;\\"paymentLink\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"pluginId\\"?: number;\\"pluginName\\"?: string;\\"pluginProperties\\"?: EPayPluginSpecificApiModel[];\\"publicLink\\"?: string;\\"qrCodeLink\\"?: string;\\"statusDisplay\\"?: string;\\"token\\"?: string;\\"userAccountName\\"?: string;}
+        
+        
+        export interface EpayRequestForUserQuery {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * [Deprecated, don't use this property anymore]
+ * @deprecated Don't use this property anymore.
+ */
+\\"canBeCanceled\\": boolean;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"epayRequestStatus\\":  & (EpayRequestStatus);
+/**
+ * 
+ * - Format: date-time
+ */
+\\"expireDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'Token' for EPays that created by others]
+ * - Format: int64
+ * @deprecated Use 'Token' for EPays that created by others.
+ */
+\\"id\\": number;\\"status\\": EpayRequestActualState;
+/**
+ * 
+ * [Deprecated, use 'UserDisplayName' instead]
+ * @deprecated Use 'UserDisplayName' instead.
+ */
+\\"applicantName\\"?: string;\\"createDate\\"?: string;\\"description\\"?: string;\\"expireDate\\"?: string;\\"paymentUrl\\"?: string;\\"statusDisplay\\"?: string;\\"token\\"?: string;\\"userAccountNumber\\"?: string;\\"userDisplayName\\"?: string;}
+        
+        
+        export interface EpayRequestPayInput {\\"description\\"?: string;}
+        
+        
+        export interface EpayRequestPluginSpecificInput {\\"pluginPropertyId\\"?: string;\\"value\\"?: string;}
+        
+        
+        export interface EpayRequestPublicInfoApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"expireDate\\": string;\\"status\\": EpayRequestStatus;\\"description\\"?: string;\\"expireDateDisplay\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"payDate\\"?: string;\\"payDateDisplay\\"?: string;\\"payerName\\"?: string;\\"paymentUrl\\"?: string;\\"statusDisplay\\"?: string;\\"token\\"?: string;\\"userAccountNumber\\"?: string;\\"userAvatarUrl\\"?: string;\\"userDisplayName\\"?: string;}
+        
+        
+        export interface EpayRequestServiceInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"callbackType\\": CallbackType;
+/**
+ * 
+ * - Format: guid
+ */
+\\"clientId\\": string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"domainId\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"expiresAfterDays\\": number;\\"getComissionFromPayer\\": boolean;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"invoiceDate\\": string;\\"isAutoConfirm\\": boolean;\\"isAutoRedirect\\": boolean;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userAccountId\\": number;
+/**
+ * 
+ * - Format: guid
+ * - minLength: 1
+ */
+\\"userId\\": string;\\"audiences\\"?: EPayRequestAudienceInput[];\\"callbackUrl\\"?: string;\\"description\\"?: string;\\"invoiceNumber\\"?: string;}
+        
+        
+        export enum EpayRequestStatus {Initiated=\\"Initiated\\",Paid=\\"Paid\\",Cancelled=\\"Cancelled\\",Expired=\\"Expired\\",Viewed=\\"Viewed\\"}
+        
+        
+        export interface EpayRequestTaskInput {\\"epayRequestTaskType\\": EpayRequestTaskType;}
+        
+        
+        export enum EpayRequestTaskType {Resend=\\"Resend\\",Cancel=\\"Cancel\\"}
+        
+        
+        export enum EpayRequestType {Link=\\"Link\\",POS=\\"POS\\",Divide=\\"Divide\\",DivideWithBlock=\\"DivideWithBlock\\",Charge=\\"Charge\\",IPG=\\"IPG\\"}
+        
+        
+        export interface EpayRequestWcfResult {\\"paymentUrl\\"?: string;\\"requestToken\\"?: string;}
+        
+        
+        export enum FieldDisplayType {String=\\"String\\",Text=\\"Text\\",Currency=\\"Currency\\",Integer=\\"Integer\\",Float=\\"Float\\",Boolean=\\"Boolean\\",List=\\"List\\"}
+        
+        
+        export interface FileApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"fileSize\\": number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"uniqueId\\": string;\\"fileName\\"?: string;\\"fileUrl\\"?: string;}
+        
+        
+        export enum FileTypes {Other=\\"Other\\",Image=\\"Image\\",Pdf=\\"Pdf\\"}
+        
+        
+        export interface ForgetPasswordQuery {\\"token\\"?: string;}
+        
+        
+        export interface FullRegisterApiModel {\\"fullName\\"?: string;\\"introducerCode\\"?: string;\\"phoneNumber\\"?: string;}
+        
+        
+        export enum Gender {Unknown=\\"Unknown\\",Male=\\"Male\\",Female=\\"Female\\"}
+        
+        
+        export interface GetBusinessUserConnectionActiveQueryParams {
+/**
+ * 
+ * defaults to 0
+ * - Format: int32
+ */
+\\"skip\\"?: number;
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;}
+        
+        
+        export interface GetBusinessUserConnectionConnectionIdEpayQueryParams {
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endDate\\"?: string;\\"epayRequestStatus\\"?: \\"Initiated\\" | \\"Paid\\" | \\"Cancelled\\" | \\"Expired\\" | \\"Viewed\\";
+/**
+ * 
+ * - Format: int32
+ */
+\\"pluginId\\"?: number;\\"plugin_SepidarCustomerName\\"?: string;\\"plugin_SepidarCustomerNumber\\"?: string;\\"plugin_SepidarDocumentNumber\\"?: string;\\"plugin_SepidarVoucherType\\"?: string;\\"plugin_ZhenicCustomerName\\"?: string;\\"plugin_ZhenicCustomerNumber\\"?: string;\\"plugin_ZhenicDollarAmount\\"?: string;\\"plugin_ZhenicDollarAmountRate\\"?: string;\\"plugin_ZhenicEuroAmount\\"?: string;\\"plugin_ZhenicEuroAmountRate\\"?: string;\\"plugin_ZhenicInvoiceNumber\\"?: string;\\"plugin_ZhenicRialAmount\\"?: string;
+/**
+ * 
+ * defaults to 0
+ * - Format: int32
+ */
+\\"skip\\"?: number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startDate\\"?: string;
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface GetBusinessUserConnectionQueryParams {
+/**
+ * 
+ * defaults to 0
+ * - Format: int32
+ */
+\\"skip\\"?: number;\\"states\\"?:  & (SubUserConnectionStatus)[];\\"subUserConnectionStatus\\"?: \\"Pending\\" | \\"Rejected\\" | \\"Connected\\" | \\"Disconnected\\" | \\"Deleted\\";
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;}
+        
+        
+        export interface GetEpayRequestCountQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Year\\"?: number;}
+        
+        
+        export interface GetEpayRequestExcelQueryParams {\\"accountIds\\"?: number[];
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endDate\\"?: string;\\"epayRequestStatus\\"?: \\"Initiated\\" | \\"Paid\\" | \\"Cancelled\\" | \\"Expired\\" | \\"Viewed\\";
+/**
+ * 
+ * - Format: int32
+ */
+\\"pluginId\\"?: number;\\"plugin_SepidarCustomerName\\"?: string;\\"plugin_SepidarCustomerNumber\\"?: string;\\"plugin_SepidarDocumentNumber\\"?: string;\\"plugin_SepidarVoucherType\\"?: string;\\"plugin_ZhenicCustomerName\\"?: string;\\"plugin_ZhenicCustomerNumber\\"?: string;\\"plugin_ZhenicDollarAmount\\"?: string;\\"plugin_ZhenicDollarAmountRate\\"?: string;\\"plugin_ZhenicEuroAmount\\"?: string;\\"plugin_ZhenicEuroAmountRate\\"?: string;\\"plugin_ZhenicInvoiceNumber\\"?: string;\\"plugin_ZhenicRialAmount\\"?: string;
+/**
+ * 
+ * defaults to 0
+ * - Format: int32
+ */
+\\"skip\\"?: number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startDate\\"?: string;\\"states\\"?:  & (EpayRequestActualState)[];
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface GetEpayRequestForMeCountQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Year\\"?: number;}
+        
+        
+        export interface GetEpayRequestForMeQueryParams {\\"applicantName\\"?: string;\\"applicantPhoneNumber\\"?: string;\\"endDate\\"?: string;
+/**
+ * 
+ * obsoleted
+ */
+\\"epayRequestStatus\\"?: \\"Initiated\\" | \\"Paid\\" | \\"Cancelled\\" | \\"Expired\\" | \\"Viewed\\";
+/**
+ * 
+ * defaults to 0
+ * - Format: int32
+ */
+\\"skip\\"?: number;\\"startDate\\"?: string;\\"states\\"?:  & (EpayRequestActualState)[];
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;}
+        
+        
+        export interface GetEpayRequestForMeReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Year\\"?: number;}
+        
+        
+        export interface GetEpayRequestPosQrAccountNumberQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"subUserConId\\"?: number;}
+        
+        
+        export interface GetEpayRequestQueryParams {\\"accountIds\\"?: number[];
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endDate\\"?: string;\\"epayRequestStatus\\"?: \\"Initiated\\" | \\"Paid\\" | \\"Cancelled\\" | \\"Expired\\" | \\"Viewed\\";
+/**
+ * 
+ * - Format: int32
+ */
+\\"pluginId\\"?: number;\\"plugin_SepidarCustomerName\\"?: string;\\"plugin_SepidarCustomerNumber\\"?: string;\\"plugin_SepidarDocumentNumber\\"?: string;\\"plugin_SepidarVoucherType\\"?: string;\\"plugin_ZhenicCustomerName\\"?: string;\\"plugin_ZhenicCustomerNumber\\"?: string;\\"plugin_ZhenicDollarAmount\\"?: string;\\"plugin_ZhenicDollarAmountRate\\"?: string;\\"plugin_ZhenicEuroAmount\\"?: string;\\"plugin_ZhenicEuroAmountRate\\"?: string;\\"plugin_ZhenicInvoiceNumber\\"?: string;\\"plugin_ZhenicRialAmount\\"?: string;
+/**
+ * 
+ * defaults to 0
+ * - Format: int32
+ */
+\\"skip\\"?: number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startDate\\"?: string;\\"states\\"?:  & (EpayRequestActualState)[];
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface GetEpayRequestReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Year\\"?: number;}
+        
+        
+        export interface GetEpayRequestUserWalletIdCommissionQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;}
+        
+        
+        export interface GetGroupTransferCommissionQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface GetIntegrationQueryParams {
+/**
+ * 
+ * code of the corresponding institude
+ * - Format: int32
+ */
+\\"instituteCode\\"?: number;
+/**
+ * 
+ * code specific to each driver
+ */
+\\"termainalId\\"?: string;}
+        
+        
+        export interface GetKpiCurrentQueryParams {\\"datePart\\"?: DatePart[];\\"kpiName\\"?: string[];}
+        
+        
+        export interface GetKpiLastQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"count\\"?: number;\\"datePart\\"?: DatePart[];\\"endPartial\\"?: boolean;\\"kpiName\\"?: string[];}
+        
+        
+        export interface GetKpiQueryParams {\\"datePart\\"?: DatePart[];
+/**
+ * 
+ * - Format: date-time
+ */
+\\"end\\"?: string;\\"endPartial\\"?: boolean;\\"kpiName\\"?: string[];
+/**
+ * 
+ * - Format: date-time
+ */
+\\"start\\"?: string;\\"startPartial\\"?: boolean;}
+        
+        
+        export interface GetNotificationUnreadQueryParams {\\"channels\\"?: NotificationChannel[];}
+        
+        
+        export interface GetPosAccountNumberQueryParams {
+/**
+ * 
+ * Subuser Connection Id
+ * - Format: int64
+ */
+\\"subUserConId\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardCommissionReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardCommissionSumQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardIntroducedCountQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardIntroducedReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardLinksCountQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardLinksPaidCountQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardLinksPaidReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardLinksReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardTransactionsCountQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardTransactionsReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserIntroducedQueryParams {\\"identityStatuses\\"?: IdentityStatus[];\\"isActive\\"?: boolean;\\"isPerson\\"?: boolean;
+/**
+ * 
+ * YYYY-MM-DD
+ * - Format: date-time
+ */
+\\"lastActivityFrom\\"?: string;
+/**
+ * 
+ * YYYY-MM-DD
+ * - Format: date-time
+ */
+\\"lastActivityTo\\"?: string;\\"orderBy\\"?: string;\\"orderDesc\\"?: boolean;
+/**
+ * 
+ * YYYY-MM-DD
+ * - Format: date-time
+ */
+\\"registeredFrom\\"?: string;
+/**
+ * 
+ * YYYY-MM-DD
+ * - Format: date-time
+ */
+\\"registeredTo\\"?: string;\\"searchInput\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"skip\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"take\\"?: number;}
+        
+        
+        export interface GetTransactionExcelQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amountFrom\\"?: number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amountTo\\"?: number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endDate\\"?: string;\\"logicalActions\\"?:  & (LogicalActionType)[];\\"operationType\\"?: \\"Unknown\\" | \\"Normal\\" | \\"System\\" | \\"DomainCommission\\" | \\"ResellerCommission\\" | \\"Block\\" | \\"Unblock\\" | \\"Refund\\" | \\"NoCommissionRemainGift\\" | \\"RemainGift\\" | \\"DomainBankBatchTransfer\\" | \\"SettlementBatchTransferItem\\" | \\"Synchronization\\" | \\"BlockchainWithdrawInternalTransfer\\" | \\"BlockchainWithdrawUserWallet\\" | \\"BlockchainIncomingTransaction\\" | \\"BlockchainWithdrawUserWalletOffchain\\" | \\"BlockchainFee\\";\\"operationTypes\\"?:  & (TransactionOperationType)[];
+/**
+ * 
+ * - Format: int32
+ */
+\\"skip\\"?: number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startDate\\"?: string;
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;\\"transactionType\\"?: \\"Debt\\" | \\"Credit\\";\\"transactionTypes\\"?:  & (TransactionType)[];
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;\\"voucherTypes\\"?:  & (VoucherOperationType)[];}
+        
+        
+        export interface GetTransactionQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amountFrom\\"?: number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amountTo\\"?: number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endDate\\"?: string;
+/**
+ * 
+ * deprecated. use 'take' instead.
+ * - Format: int32
+ */
+\\"limit\\"?: number;\\"logicalActions\\"?:  & (LogicalActionType)[];\\"operationType\\"?: \\"Unknown\\" | \\"Normal\\" | \\"System\\" | \\"DomainCommission\\" | \\"ResellerCommission\\" | \\"Block\\" | \\"Unblock\\" | \\"Refund\\" | \\"NoCommissionRemainGift\\" | \\"RemainGift\\" | \\"DomainBankBatchTransfer\\" | \\"SettlementBatchTransferItem\\" | \\"Synchronization\\" | \\"BlockchainWithdrawInternalTransfer\\" | \\"BlockchainWithdrawUserWallet\\" | \\"BlockchainIncomingTransaction\\" | \\"BlockchainWithdrawUserWalletOffchain\\" | \\"BlockchainFee\\";\\"operationTypes\\"?:  & (TransactionOperationType)[];
+/**
+ * 
+ * - Format: int32
+ */
+\\"skip\\"?: number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startDate\\"?: string;
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;\\"transactionType\\"?: \\"Debt\\" | \\"Credit\\";\\"transactionTypes\\"?:  & (TransactionType)[];
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;\\"voucherTypes\\"?:  & (VoucherOperationType)[];}
+        
+        
+        export interface GetTransactionReportAllQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Year\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"accountId\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"businessCategoryId\\"?: number;\\"operationType\\"?: \\"Unknown\\" | \\"Normal\\" | \\"System\\" | \\"DomainCommission\\" | \\"ResellerCommission\\" | \\"Block\\" | \\"Unblock\\" | \\"Refund\\" | \\"NoCommissionRemainGift\\" | \\"RemainGift\\" | \\"DomainBankBatchTransfer\\" | \\"SettlementBatchTransferItem\\" | \\"Synchronization\\" | \\"BlockchainWithdrawInternalTransfer\\" | \\"BlockchainWithdrawUserWallet\\" | \\"BlockchainIncomingTransaction\\" | \\"BlockchainWithdrawUserWalletOffchain\\" | \\"BlockchainFee\\";\\"type\\"?: \\"Debt\\" | \\"Credit\\";}
+        
+        
+        export interface GetTransactionReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Year\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"accountId\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"businessCategoryId\\"?: number;\\"operationType\\"?: \\"Unknown\\" | \\"Normal\\" | \\"System\\" | \\"DomainCommission\\" | \\"ResellerCommission\\" | \\"Block\\" | \\"Unblock\\" | \\"Refund\\" | \\"NoCommissionRemainGift\\" | \\"RemainGift\\" | \\"DomainBankBatchTransfer\\" | \\"SettlementBatchTransferItem\\" | \\"Synchronization\\" | \\"BlockchainWithdrawInternalTransfer\\" | \\"BlockchainWithdrawUserWallet\\" | \\"BlockchainIncomingTransaction\\" | \\"BlockchainWithdrawUserWalletOffchain\\" | \\"BlockchainFee\\";\\"type\\"?: \\"Debt\\" | \\"Credit\\";}
+        
+        
+        export interface GetTransferRecentQueryParams {
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;}
+        
+        
+        export interface GetTransferSearchQueryParams {\\"accountNumber\\"?: string;
+/**
+ * 
+ * Phone number or email address
+ */
+\\"contact\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"customerNumber\\"?: number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface GetTransferUserWalletIdCommissionQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;}
+        
+        
+        export interface GetUserWalletAccountNumberQrcodeQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"subUserConId\\"?: number;}
+        
+        
+        export interface GetUserWalletSearchQueryParams {\\"accountNumber\\"?: string;\\"contact\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"customerNumber\\"?: number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface GetUserWalletUserWalletIdEpayRequestComissionQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;}
+        
+        
+        export interface GetUserWalletUserWalletIdSettlementRequestComissionQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;}
+        
+        
+        export interface GetUserWalletUserWalletIdTransferMoneyCommissionQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;}
+        
+        
+        export interface GroupTransferInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"totalAmount\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"description\\"?: string;\\"targets\\"?: GroupTransferTargetInput[];}
+        
+        
+        export interface GroupTransferQuery {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDate\\": string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"voucherId\\": number;\\"createDateDisplay\\"?: string;\\"description\\"?: string;\\"targets\\"?: GroupTransferTargetQuery[];\\"userAccountName\\"?: string;\\"userDisplayName\\"?: string;}
+        
+        
+        export interface GroupTransferTargetInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"description\\"?: string;\\"identifier\\"?: string;}
+        
+        
+        export interface GroupTransferTargetQuery {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"accountName\\"?: string;\\"description\\"?: string;\\"userDisplayName\\"?: string;\\"userPhoneNumber\\"?: string;}
+        
+        
+        export enum GroupTransferTargetStatus {InvalidIdentifier=\\"InvalidIdentifier\\",Ok=\\"Ok\\",Unregistered=\\"Unregistered\\",BlockedAccount=\\"BlockedAccount\\",InvalidAmount=\\"InvalidAmount\\"}
+        
+        
+        export interface GroupTransferTargetValidationInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"description\\"?: string;
+/**
+ * 
+ * PhoneNumber or Account Number
+ */
+\\"identifier\\"?: string;}
+        
+        
+        export interface GroupTransferTargetValidationQuery {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"identifierType\\": UserIdentifierType;\\"status\\": GroupTransferTargetStatus;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userCustomerNumber\\": number;\\"accountNumber\\"?: string;\\"identifier\\"?: string;\\"identifierTypeDisplay\\"?: string;\\"name\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'StatusDisplay' instead]
+ * @deprecated Use 'StatusDisplay' instead.
+ */
+\\"statusDescription\\"?: string;\\"statusDisplay\\"?: string;\\"userDisplayName\\"?: string;\\"userPhoneNumber\\"?: string;}
+        
+        
+        export enum IPGStatus {NotRequested=\\"NotRequested\\"}
+        
+        
+        export enum IdentityStatus {None=\\"None\\",WatingForCheck=\\"WatingForCheck\\",Checking=\\"Checking\\",EditingRequired=\\"EditingRequired\\",Approved=\\"Approved\\",Rejected=\\"Rejected\\"}
+        
+        
+        export interface ImportantActionApiModel {\\"closeable\\": boolean;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createTime\\": string;\\"dismissible\\": boolean;
+/**
+ * 
+ * - Format: int32
+ */
+\\"id\\": number;\\"isSeen\\": boolean;\\"level\\": NotificationLevel;\\"type\\": NotificationModelType;\\"data\\"?: string;\\"dataId\\"?: string;\\"levelDisplay\\"?: string;\\"text\\"?: string;\\"title\\"?: string;\\"typeDisplay\\"?: string;}
+        
+        
+        export interface InitApiModel {\\"versionState\\": TerminalVersionState;\\"appDownloadLink\\"?: string;\\"versionStateDisplay\\"?: string;}
+        
+        
+        export interface KpiResult {
+/**
+ * 
+ * - Format: date-time
+ */
+\\"end\\": string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"start\\": string;\\"datePart\\"?:  & (DatePart);\\"kpiName\\"?: string;\\"targetIds\\"?: string[];\\"values\\"?: KpiResultValue[];}
+        
+        
+        export interface KpiResultValue {
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endPoint\\": string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"extractedTime\\": string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startPoint\\": string;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"value\\": number;\\"targetId\\"?: string;}
+        
+        
+        export enum LogEventLevel {Verbose=\\"Verbose\\",Debug=\\"Debug\\",Information=\\"Information\\",Warning=\\"Warning\\",Error=\\"Error\\",Fatal=\\"Fatal\\"}
+        
+        
+        export interface LogSetting {\\"globalLogLevel\\": LogEventLevel;\\"septaPayLogLevel\\": LogEventLevel;\\"serilogLogLevel\\": LogEventLevel;}
+        
+        
+        export enum LogicalActionType {EpayRequest=\\"EpayRequest\\",TransferMoney=\\"TransferMoney\\",AccountChargeRequest=\\"AccountChargeRequest\\",ServiceBill=\\"ServiceBill\\",ServiceMobileCharge=\\"ServiceMobileCharge\\",POS=\\"POS\\",ShareAndBlockRequest=\\"ShareAndBlockRequest\\",ShareRequest=\\"ShareRequest\\",Settlement=\\"Settlement\\",GroupTransferMoney=\\"GroupTransferMoney\\",ShareAndUnblock=\\"ShareAndUnblock\\",Refund=\\"Refund\\",PayCommand=\\"PayCommand\\",Gift=\\"Gift\\",TaxiFairPayment=\\"TaxiFairPayment\\",HitoBitFee=\\"HitoBitFee\\"}
+        
+        
+        export interface MachineSignUp {
+/**
+ * 
+ * - Format: int64
+ */
+\\"customerNumber\\": number;\\"apiKey\\"?: string;}
+        
+        
+        export interface NewChargeRequestInput {
+/**
+ * 
+ * مبلغ شارژ
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * آدرس بازگشت بعد از پرداخت
+ */
+\\"callbackUrl\\"?: string;}
+        
+        
+        export interface NewChargeRequestResultQuery {\\"paymentLink\\"?: string;}
+        
+        
+        export interface NewEpayRequestInput {
+/**
+ * 
+ * مبلغ شارژ
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * نوع ارجاع در هنگام ایجاد درخواست
+ */
+\\"callbackType\\":  & (CallbackType);
+/**
+ * 
+ * تاریخ انتقضا لینک ایجاد شده
+ * - Format: int32
+ */
+\\"expireDays\\": number;
+/**
+ * 
+ * انتقال مستقیم به درگاه
+ 
+ */
+\\"isAutoConfirm\\": boolean;
+/**
+ * 
+ * - Format: guid
+ */
+\\"assisstantUserId\\"?: string;
+/**
+ * 
+ * اطلاعات پرداخت کننده / ها
+ */
+\\"audiences\\"?: EPayRequestAudienceInput[];
+/**
+ * 
+ * آدرس بازگشت بعد از پرداخت
+ */
+\\"callbackUrl\\"?: string;
+/**
+ * 
+ * توضحیات درخواست (بابت)
+ */
+\\"description\\"?: string;
+/**
+ * 
+ * نحوه دریافت کارمزد
+ */
+\\"getComissionByPayer\\"?: boolean;
+/**
+ * 
+ * تاریخ فاکتور
+ * - Format: date-time
+ */
+\\"invoiceDate\\"?: string;
+/**
+ * 
+ * شماره فاکتور
+ */
+\\"invoiceNumber\\"?: string;
+/**
+ * 
+ * ...
+ * - Format: int32
+ */
+\\"pluginId\\"?: number;
+/**
+ * 
+ * ...
+ */
+\\"pluginSpecifics\\"?: EpayRequestPluginSpecificInput[];}
+        
+        
+        export interface NewUserIdentityRequestInput {\\"documents\\"?: DocumentInput[];\\"firstName\\"?: string;\\"lastName\\"?: string;\\"nationalCode\\"?: string;}
+        
+        
+        export interface NotificationApiModel {
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createTime\\": string;\\"isSeen\\": boolean;\\"level\\": NotificationLevel;\\"type\\": NotificationModelType;\\"dataId\\"?: string;\\"levelDisplay\\"?: string;\\"text\\"?: string;\\"title\\"?: string;\\"typeDisplay\\"?: string;}
+        
+        
+        export enum NotificationChannel {Notification=\\"Notification\\",ImportantAction=\\"ImportantAction\\",SMS=\\"SMS\\",Email=\\"Email\\",FCM=\\"FCM\\",SignalR=\\"SignalR\\"}
+        
+        
+        export enum NotificationLevel {Unknown=\\"Unknown\\",Default=\\"Default\\",Success=\\"Success\\",Info=\\"Info\\",Warning=\\"Warning\\",Danger=\\"Danger\\"}
+        
+        
+        export enum NotificationModelType {Default=\\"Default\\",EPayRequestUnpaid=\\"EPayRequestUnpaid\\",EPayRequestPaid=\\"EPayRequestPaid\\",UserIdentityUnknown=\\"UserIdentityUnknown\\",UserIdentityApproved=\\"UserIdentityApproved\\",UserIdentityRejected=\\"UserIdentityRejected\\",UpgradeToBusinessApproved=\\"UpgradeToBusinessApproved\\",UpgradeToBusinessRejected=\\"UpgradeToBusinessRejected\\",UserBankApproved=\\"UserBankApproved\\",UserBankRejected=\\"UserBankRejected\\",SubUserConnectionCreated=\\"SubUserConnectionCreated\\",SubUserInvitationRejected=\\"SubUserInvitationRejected\\",SubUserInvitationSent=\\"SubUserInvitationSent\\",MoneyDeposit=\\"MoneyDeposit\\",MoneyWithdrawal=\\"MoneyWithdrawal\\",SubUserDisconnectedByBusiness=\\"SubUserDisconnectedByBusiness\\",SubUserDisconnectedBySubUser=\\"SubUserDisconnectedBySubUser\\",Activities=\\"Activities\\",TradeNotification=\\"TradeNotification\\",HitoBitNews=\\"HitoBitNews\\",SystemMessages=\\"SystemMessages\\"}
+        
+        
+        export enum PlatformType {Unknown=\\"Unknown\\",Server=\\"Server\\",Android=\\"Android\\",iOS=\\"iOS\\",Device=\\"Device\\",Browser=\\"Browser\\",PWA=\\"PWA\\",Web=\\"Web\\",Windows=\\"Windows\\",Linux=\\"Linux\\",macOS=\\"macOS\\",Desktop=\\"Desktop\\"}
+        
+        
+        export interface PluginApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"id\\": number;\\"amountCalculationExpression\\"?: string;\\"logoFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"logoFileUniqueId\\"?: string;\\"logoFileUrl\\"?: string;\\"name\\"?: string;\\"properties\\"?: PluginPropertyApiModel[];}
+        
+        
+        export interface PluginPropertyApiModel {\\"fieldType\\": FieldDisplayType;\\"isFilterable\\": boolean;\\"isRequired\\": boolean;\\"currencyName\\"?: string;\\"description\\"?: string;\\"name\\"?: string;\\"title\\"?: string;\\"value\\"?: string;}
+        
+        
+        export interface PosLandingPageApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"domainId\\": number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"accountNumber\\"?: string;\\"domainEnglishName\\"?: string;\\"domainLogoFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"domainLogoFileUniqueId\\"?: string;\\"domainLogoFileUrl\\"?: string;\\"domainPersianName\\"?: string;\\"getCommissionFromPayer\\"?: boolean;\\"subUserAvatarFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"subUserAvatarFileUniqueId\\"?: string;\\"subUserAvatarFileUrl\\"?: string;\\"subUserDisplayName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"subUserId\\"?: string;\\"userAvatarFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userAvatarFileUniqueId\\"?: string;\\"userAvatarFileUrl\\"?: string;\\"userDisplayName\\"?: string;}
+        
+        
+        export interface PosOnlinePayInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"callBackUrl\\"?: string;\\"callbackType\\"?:  & (CallbackType);\\"description\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"subuserId\\"?: string;}
+        
+        
+        export interface PosWalletPayInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"description\\"?: string;}
+        
+        
+        export interface RegisterApiModel {\\"deviceBrandName\\"?: string;\\"deviceId\\"?: string;\\"deviceOsVersion\\"?: string;\\"deviceToken\\"?: string;\\"phoneNumber\\"?: string;}
+        
+        
+        export interface RegisterNewUserQuery {
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"token\\"?: string;}
+        
+        
+        export interface ReportApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"count\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"day\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"dayOfWeek\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"key\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"sum\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\": number;\\"dayName\\"?: string;\\"label\\"?: string;\\"monthName\\"?: string;
+/**
+ * 
+ * سال دو رقمی
+ */
+\\"yearShort\\"?: string;}
+        
+        
+        export type RequestBodyAccountCreationApiModel = AccountCreationApiModel
+        
+        
+        export interface RequestBodyFile_Upload {
+/**
+ * 
+ * - Format: binary
+ */
+\\"file\\"?: string;}
+        
+        
+        export type RequestBodyLogEventLevel = LogEventLevel
+        
+        
+        export type RequestBodyNewEpayRequestInput = NewEpayRequestInput
+        
+        
+        export type RequestBodySubUserNotificationStatusInput = SubUserNotificationStatusInput
+        
+        
+        export type RequestBodyTransferMoneyInput = TransferMoneyInput
+        
+        
+        export type RequestBodyUserBankInput = UserBankInput
+        
+        
+        export interface RequestTotpInput {\\"phoneNumber\\"?: string;}
+        
+        
+        export interface ReselledUserActivityApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"commissionsPaidToResellerCount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionsPaidToResellerSum\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"generatedLinks\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"paidGeneratedLinks\\": number;}
+        
+        
+        export interface ReselledUserApiModel {\\"identityStatus\\": IdentityStatus;\\"ipgStatus\\": IPGStatus;\\"isActive\\": boolean;\\"isBussinessUser\\": boolean;\\"isPerson\\": boolean;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"userStatus\\": UserStatus;\\"displayName\\"?: string;\\"identityStatusDisplay\\"?: string;\\"imageUrl\\"?: string;\\"ipgStatusDisplay\\"?: string;\\"lastActivityDate\\"?: string;\\"phoneNumber\\"?: string;\\"registerDate\\"?: string;}
+        
+        
+        export interface ReselledUserFilterData {\\"identityStatuses\\"?:  & (DropDownResultOfIdentityStatus);}
+        
+        
+        export interface ResellerApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"commissionId\\": number;\\"commissionType\\": ComissionType;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endDate\\": string;\\"hasSubDomain\\": boolean;\\"isActive\\": boolean;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startDate\\": string;\\"commissionDisplay\\"?: string;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionFixedValue\\"?: number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionMaxValue\\"?: number;\\"commissionName\\"?: string;
+/**
+ * 
+ * - Format: double
+ */
+\\"commissionPercent\\"?: number;\\"commissionTypeDisplay\\"?: string;\\"endDateDisplay\\"?: string;\\"introduceLink\\"?: string;\\"startDateDisplay\\"?: string;}
+        
+        
+        export interface SendConnectionRequestInput {\\"email\\"?: string;\\"phoneNumber\\"?: string;\\"position\\"?: string;}
+        
+        
+        export enum SepidResponseType {Succesful=\\"Succesful\\",Unsuccesful=\\"Unsuccesful\\"}
+        
+        
+        export interface SetAccountAccessForSubUserInput {
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface SetUserBasicInfoInput {
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"firstName\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"introducerCode\\"?: number;\\"lastName\\"?: string;\\"password\\"?: string;}
+        
+        
+        export interface SettingApiModel {\\"logSetting\\"?:  & (LogSetting);}
+        
+        
+        export interface SubDomainApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"domainId\\": number;\\"isActive\\": boolean;
+/**
+ * 
+ * - Format: guid
+ */
+\\"resellerUserId\\": string;\\"about\\"?: string;\\"domainEnglishName\\"?: string;\\"domainPersianName\\"?: string;\\"englishName\\"?: string;\\"logoFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"logoFileUniqueId\\"?: string;\\"logoFileUrl\\"?: string;\\"persianName\\"?: string;\\"resellerUserDisplayName\\"?: string;\\"subDomainAddress\\"?: string;}
+        
+        
+        export interface SubDomainUpdateApiModel {\\"about\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"logoFileUniqueId\\"?: string;}
+        
+        
+        export interface SubUserAccountDetailQuery {\\"accountStatus\\": AccountStatus;\\"canAssistantsCreatesEpayRequest\\": boolean;\\"canChargeAccount\\": boolean;\\"canReceiveMoney\\": boolean;\\"canRequestSettlement\\": boolean;\\"canSeeEpayRequests\\": boolean;\\"canSeeSettlementRequests\\": boolean;\\"canSeeTransactions\\": boolean;\\"canTransferMoney\\": boolean;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"isActive\\": boolean;\\"notificationEnabled\\": boolean;
+/**
+ * 
+ * - Format: int32
+ */
+\\"posPaidCount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"posScanCount\\": number;\\"accountNumber\\"?: string;\\"accountQrCodeUrl\\"?: string;\\"accountStatusDisplay\\"?: string;\\"name\\"?: string;\\"posLinkUrl\\"?: string;}
+        
+        
+        export interface SubUserActivityApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"accountChargeRequestAmount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"accountChargeRequestCount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"paidEpayRequestAmount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"paidEpayRequestCount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"settlementRequestAmount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"settlementRequestCount\\": number;}
+        
+        
+        export interface SubUserConnectionApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"invitationId\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"requestDateTime\\": string;\\"status\\": SubUserConnectionStatus;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead,
+ */
+\\"subUserConnectionStatus\\":  & (SubUserConnectionStatus);\\"connectDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"connectDateTime\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"connectionId\\"?: number;\\"disconnectDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"disconnectDateTime\\"?: string;\\"removeDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"removeDateTime\\"?: string;\\"requestDate\\"?: string;\\"statusDisplay\\"?: string;\\"subUserAvatarUrl\\"?: string;\\"subUserContact\\"?: string;\\"subUserPositionTitle\\"?: string;\\"subUserTitle\\"?: string;}
+        
+        
+        export enum SubUserConnectionStatus {Pending=\\"Pending\\",Rejected=\\"Rejected\\",Connected=\\"Connected\\",Disconnected=\\"Disconnected\\",Deleted=\\"Deleted\\"}
+        
+        
+        export interface SubUserInvitationApiModel {
+/**
+ * 
+ * - Format: date-time
+ */
+\\"invitationDate\\": string;
+/**
+ * 
+ * [Deprecated, use 'InvitationToken' to call new endpoints]
+ * - Format: int64
+ * @deprecated Use 'InvitationToken' to call new endpoints.
+ */
+\\"invitationId\\": number;\\"businessUserAvatarUrl\\"?: string;\\"businessUserTitle\\"?: string;\\"invitationToken\\"?: string;\\"message\\"?: string;}
+        
+        
+        export interface SubUserNotificationStatusInput {\\"notificationEnabled\\": boolean;}
+        
+        
+        export interface SubUserPermissionApiModel {\\"canAccessToAccount\\": boolean;\\"canAssistantsCreatesEpayRequest\\": boolean;\\"canChargeAccount\\": boolean;\\"canGroupTransferMoney\\": boolean;\\"canReceiveMoney\\": boolean;\\"canRequestSettlement\\": boolean;\\"canSeeEpayRequests\\": boolean;\\"canSeeSettlementRequests\\": boolean;\\"canSeeTransactions\\": boolean;\\"canTransferMoney\\": boolean;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"realBalance\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"totalBalance\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"accountNumber\\"?: string;\\"accountTitle\\"?: string;}
+        
+        
+        export enum SubUserPermissionType {Default=\\"Default\\",CanReceiveMoney=\\"CanReceiveMoney\\",CanSeeEpayRequests=\\"CanSeeEpayRequests\\",CanTransferMoney=\\"CanTransferMoney\\",CanSeeTransactions=\\"CanSeeTransactions\\",CanRequestSettlement=\\"CanRequestSettlement\\",CanChargeAccount=\\"CanChargeAccount\\",CanSeeSettlementRequests=\\"CanSeeSettlementRequests\\",CanGroupTransferMoney=\\"CanGroupTransferMoney\\",CanAssistantsCreatesEpayRequest=\\"CanAssistantsCreatesEpayRequest\\"}
+        
+        
+        export interface SubuserInvitationTaskInput {\\"subuserInvitationTaskType\\": SubuserInvitationTaskType;}
+        
+        
+        export enum SubuserInvitationTaskType {Accept=\\"Accept\\",Reject=\\"Reject\\"}
+        
+        
+        export enum SubuserStatus {Connected=\\"Connected\\",DisconnectedByBusinessUser=\\"DisconnectedByBusinessUser\\",DisconnectedBySubUser=\\"DisconnectedBySubUser\\"}
+        
+        
+        export interface TaxiInfoOutput {\\"carTypeCode\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"lineCode\\": number;\\"activityType\\"?: string;\\"destination\\"?: string;\\"source\\"?: string;\\"vehicleColor\\"?: string;\\"vehicleType\\"?: string;}
+        
+        
+        export enum TaxiPaymentProvider {Sepid=\\"Sepid\\",Simorgh=\\"Simorgh\\"}
+        
+        
+        export interface TaxiPriceOutput {
+/**
+ * 
+ * - Format: int64
+ */
+\\"amount\\": number;\\"currency\\"?: string;\\"title\\"?: string;}
+        
+        
+        export interface TaxiRecieptApiDto {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"dateTime\\": string;\\"sepidResponse\\": SepidResponseType;\\"taxiProvider\\": TaxiPaymentProvider;\\"accountName\\"?: string;\\"accountNumber\\"?: string;\\"sepidResponseDisplay\\"?: string;\\"taxiProviderDisplay\\"?: string;}
+        
+        
+        export interface TerminalVersionApiModel {\\"currentVersion\\"?: string;\\"minimumVersion\\"?: string;}
+        
+        
+        export enum TerminalVersionState {Default=\\"Default\\",UpToDate=\\"UpToDate\\",Supported=\\"Supported\\",Deprecated=\\"Deprecated\\"}
+        
+        
+        export interface TotpLoginResult {\\"token\\"?: string;}
+        
+        
+        export interface TransactionApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"accountId\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDateTime\\": string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"remain\\": number;\\"transactionOperationType\\": TransactionOperationType;\\"transactionType\\": TransactionType;
+/**
+ * 
+ * - Format: int64
+ */
+\\"voucherId\\": number;\\"accountNumber\\"?: string;\\"accountTitle\\"?: string;\\"createDate\\"?: string;\\"description\\"?: string;\\"followupId\\"?: string;\\"logicalAction\\"?:  & (LogicalActionType);\\"logicalActionDisplay\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"targetBusinessCategoryId\\"?: number;\\"targetBusinessCategoryName\\"?: string;\\"transactionOperationTypeDisplay\\"?: string;\\"transactionTypeDisplay\\"?: string;\\"voucherType\\"?:  & (VoucherOperationType);\\"voucherTypeDisplay\\"?: string;}
+        
+        
+        export enum TransactionOperationType {Unknown=\\"Unknown\\",Normal=\\"Normal\\",System=\\"System\\",DomainCommission=\\"DomainCommission\\",ResellerCommission=\\"ResellerCommission\\",Block=\\"Block\\",Unblock=\\"Unblock\\",Refund=\\"Refund\\",NoCommissionRemainGift=\\"NoCommissionRemainGift\\",RemainGift=\\"RemainGift\\",DomainBankBatchTransfer=\\"DomainBankBatchTransfer\\",SettlementBatchTransferItem=\\"SettlementBatchTransferItem\\",Synchronization=\\"Synchronization\\",BlockchainWithdrawInternalTransfer=\\"BlockchainWithdrawInternalTransfer\\",BlockchainWithdrawUserWallet=\\"BlockchainWithdrawUserWallet\\",BlockchainIncomingTransaction=\\"BlockchainIncomingTransaction\\",BlockchainWithdrawUserWalletOffchain=\\"BlockchainWithdrawUserWalletOffchain\\",BlockchainFee=\\"BlockchainFee\\"}
+        
+        
+        export enum TransactionType {Debt=\\"Debt\\",Credit=\\"Credit\\"}
+        
+        
+        export interface TransferMoneyApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionAmount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'CommissionAmount' instead]
+ * - Format: decimal
+ * @deprecated Use 'CommissionAmount' instead.
+ */
+\\"domainCommissionAmount\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"payerAccountId\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"targetAccountId\\": number;
+/**
+ * 
+ * [Deprecated, use 'PayerAccountId' instead]
+ * - Format: int64
+ * @deprecated Use 'PayerAccountId' instead.
+ */
+\\"userAccountId\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"voucherId\\": number;\\"description\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'OperationId' instead]
+ * - Format: int64
+ * @deprecated Use 'OperationId' instead.
+ */
+\\"id\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"operationId\\"?: number;\\"payerAccountName\\"?: string;\\"payerAccountNumber\\"?: string;\\"targetAccountNumber\\"?: string;\\"targetUserAvatarUrl\\"?: string;\\"targetUserDisplayName\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'PayerAccountName' instead]
+ * @deprecated Use 'PayerAccountName' instead.
+ */
+\\"userAccountName\\"?: string;}
+        
+        
+        export interface TransferMoneyInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"targetUserAccountId\\": number;\\"description\\"?: string;\\"targetIdentifier\\"?: string;}
+        
+        
+        export interface UnreadNotificationCountApiModel {\\"channel\\": NotificationChannel;
+/**
+ * 
+ * - Format: int32
+ */
+\\"unreadCount\\": number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;}
+        
+        
+        export interface UpgradeToBusinessApiModel {\\"businessShareType\\": BusinessShareType;\\"businessType\\": BusinessType;\\"status\\": IdentityStatus;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"upgradeToBusinessRequestStatus\\":  & (IdentityStatus);
+/**
+ * 
+ * [Deprecated, use 'BusinessShareType' instead]
+ * @deprecated Use 'BusinessShareType' instead.
+ */
+\\"userIdentityType\\":  & (BusinessShareType);\\"address\\"?: string;\\"businessLogoImageLink\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"businessLogoImageUniqueId\\"?: string;\\"businessName\\"?: string;\\"businessShareTypeDisplay\\"?: string;\\"businessTypeDisplay\\"?: string;\\"city\\"?: string;\\"description\\"?: string;\\"documents\\"?: DocumentApiModel[];\\"email\\"?: string;\\"faxNumber\\"?: string;\\"managerName\\"?: string;\\"managerPhoneNumber\\"?: string;\\"organizationName\\"?: string;\\"organizationNationalCode\\"?: string;\\"personNationalCode\\"?: string;\\"phoneNumber\\"?: string;\\"rejectCause\\"?:  & (UpgradeToBusinessRejectCause);\\"rejectCauseDescription\\"?: string;\\"rejectCauseDisplay\\"?: string;\\"state\\"?: string;\\"statusDisplay\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'RejectCauseDescription' instead]
+ * @deprecated Use 'RejectCauseDescription' instead.
+ */
+\\"upgradeToBusinessRequestStatusDescription\\"?: string;\\"webSiteUrl\\"?: string;}
+        
+        
+        export enum UpgradeToBusinessRejectCause {DocumentsLack=\\"DocumentsLack\\",DocumentsMismatch=\\"DocumentsMismatch\\",Other=\\"Other\\"}
+        
+        
+        export interface UpgradeToBusinessUserInput {\\"address\\"?: string;\\"businessName\\"?: string;\\"businessShareType\\"?:  & (BusinessShareType);\\"businessType\\"?:  & (BusinessType);\\"city\\"?: string;\\"documents\\"?: DocumentInput[];\\"email\\"?: string;\\"faxNumber\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"logoFileUniqueId\\"?: string;\\"managerName\\"?: string;\\"managerPhoneNumber\\"?: string;\\"organizationName\\"?: string;\\"organizationNationalCode\\"?: string;\\"phoneNumber\\"?: string;\\"state\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'BusinessShareType' instead]
+ * @deprecated Use 'BusinessShareType' instead.
+ */
+\\"userIdentityType\\"?:  & (BusinessShareType);\\"webSiteUrl\\"?: string;}
+        
+        
+        export interface UserBankApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"bankId\\": number;\\"businessShareType\\": BusinessShareType;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;
+/**
+ * 
+ * [Deprecated, use 'BusinessShareType' instead]
+ * @deprecated Use 'BusinessShareType' instead.
+ */
+\\"identityType\\":  & (BusinessShareType);\\"isVisible\\": boolean;\\"status\\": IdentityStatus;\\"accountNumber\\"?: string;\\"bankLogo\\"?: string;\\"bankName\\"?: string;\\"businessShareTypeDisplay\\"?: string;\\"firstName\\"?: string;\\"lastName\\"?: string;\\"name\\"?: string;\\"rejectCause\\"?:  & (UserBankRejectCause);\\"rejectCauseDescription\\"?: string;\\"rejectCauseDisplay\\"?: string;\\"shebaNo\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'RejectCauseDescription' instead]
+ * @deprecated Use 'RejectCauseDescription' instead.
+ */
+\\"statusDescription\\"?: string;\\"statusDisplay\\"?: string;}
+        
+        
+        export interface UserBankChangeVisibilityInput {\\"isVisible\\"?: boolean;}
+        
+        
+        export type UserBankDetailApiModel =  & (UserBankApiModel & {\\"documents\\"?: DocumentApiModel[];\\"nationalCode\\"?: string;})
+        
+        
+        export interface UserBankInput {\\"accountNumber\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"bankId\\"?: number;\\"businessShareType\\"?:  & (BusinessShareType);\\"documents\\"?: DocumentInput[];\\"firstName\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'BusinessShareType' instead]
+ * @deprecated Use 'BusinessShareType' instead.
+ */
+\\"identityType\\"?:  & (BusinessShareType);\\"isVisible\\"?: boolean;\\"lastName\\"?: string;\\"name\\"?: string;\\"nationalCode\\"?: string;\\"shebaNo\\"?: string;}
+        
+        
+        export enum UserBankRejectCause {DocumentsLack=\\"DocumentsLack\\",DocumentsMismatch=\\"DocumentsMismatch\\",Etc=\\"Etc\\"}
+        
+        
+        export interface UserChangePasswordInput {\\"currentPassword\\"?: string;\\"newPassword\\"?: string;}
+        
+        
+        export type UserDetailQuery =  & (UserMeQuery & {\\"address\\"?: string;\\"city\\"?: string;\\"email\\"?: string;\\"introducedBySubDomain\\"?: string;\\"nationalCode\\"?: string;\\"phoneNumber\\"?: string;\\"state\\"?: string;})
+        
+        
+        export interface UserForgetPasswordInput {\\"phoneNumber\\"?: string;}
+        
+        
+        export enum UserIdentifierType {Default=\\"Default\\",PhoneNumber=\\"PhoneNumber\\",Email=\\"Email\\",CustomerNumber=\\"CustomerNumber\\",AccountNumber=\\"AccountNumber\\"}
+        
+        
+        export enum UserIdentityRejectCause {DocumentsLack=\\"DocumentsLack\\",DocumentsMismatch=\\"DocumentsMismatch\\",DocumentsRejected=\\"DocumentsRejected\\",Etc=\\"Etc\\"}
+        
+        
+        export interface UserIdentityRequestQuery {\\"status\\": IdentityStatus;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"userIdentityRequestStatus\\":  & (IdentityStatus);\\"documents\\"?: DocumentApiModel[];\\"firstName\\"?: string;\\"lastName\\"?: string;\\"nationalCode\\"?: string;\\"rejectCause\\"?:  & (UserIdentityRejectCause);\\"rejectCauseDescription\\"?: string;\\"rejectCauseDisplay\\"?: string;\\"statusDisplay\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'RejectCauseDescription' instead]
+ * @deprecated Use 'RejectCauseDescription' instead.
+ */
+\\"userIdentityRequestStatusDescription\\"?: string;}
+        
+        
+        export interface UserMeQuery {\\"identityStatus\\": IdentityStatus;\\"isBusinessUser\\": boolean;\\"isResellerUser\\": boolean;\\"isSubUser\\": boolean;
+/**
+ * 
+ * - Format: int64
+ */
+\\"shareCode\\": number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"birthDate\\"?: string;\\"birthDateDisplay\\"?: string;\\"businessName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"businessUserId\\"?: string;\\"gender\\"?:  & (Gender);\\"genderDisplay\\"?: string;\\"identityStatusDisplay\\"?: string;\\"profileImageLink\\"?: string;\\"referredBy\\"?: string;\\"title\\"?: string;}
+        
+        
+        export interface UserMinimalDto {
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"displayName\\"?: string;\\"positionTitle\\"?: string;}
+        
+        
+        export interface UserPluginApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"isActive\\": boolean;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"pluginConfig\\"?: string;\\"pluginName\\"?: string;\\"userDisplayName\\"?: string;}
+        
+        
+        export interface UserPluginDetailApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"isActive\\": boolean;
+/**
+ * 
+ * - Format: int32
+ */
+\\"pluginId\\": number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"pluginAmountCalculationExpression\\"?: string;\\"pluginConfig\\"?: string;\\"pluginLogoFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"pluginLogoFileUniqueId\\"?: string;\\"pluginLogoFileUrl\\"?: string;\\"pluginName\\"?: string;\\"properties\\"?: PluginPropertyApiModel[];\\"userDisplayName\\"?: string;}
+        
+        
+        export interface UserPluginTogggleApiModel {\\"isActive\\": boolean;}
+        
+        
+        export interface UserProfileAvatarInput {
+/**
+ * 
+ * - Format: guid
+ */
+\\"fileUniqueId\\"?: string;}
+        
+        
+        export interface UserProfileInput {\\"address\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"birthDate\\"?: string;\\"city\\"?: string;\\"email\\"?: string;\\"gender\\"?:  & (Gender);\\"state\\"?: string;}
+        
+        
+        export enum UserStatus {None=\\"None\\",NotVerified=\\"NotVerified\\",VerifiedButNotCompleted=\\"VerifiedButNotCompleted\\",Active=\\"Active\\",TemporaryBlocked=\\"TemporaryBlocked\\",AutoPasswordGenerated=\\"AutoPasswordGenerated\\"}
+        
+        
+        export interface UserVerifyForgetPasswordInput {\\"newPassword\\"?: string;\\"phoneNumber\\"?: string;\\"token\\"?: string;\\"verifyCode\\"?: string;}
+        
+        
+        export interface UserWorkspaceQuery {
+/**
+ * 
+ * - Format: guid
+ */
+\\"businessUserId\\": string;\\"workspaceType\\": WorkspaceType;\\"businessAvatarUrl\\"?: string;\\"businessName\\"?: string;\\"positionTitle\\"?: string;}
+        
+        
+        export interface VerifyPhoneNumberInput {
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"subDomainId\\"?: string;\\"token\\"?: string;\\"verifyCode\\"?: string;}
+        
+        
+        export enum VoucherOperationType {Unknown=\\"Unknown\\",EPayViaBankWithCommissionByPayer=\\"EPayViaBankWithCommissionByPayer\\",EPayViaBankWithCommissionByUser=\\"EPayViaBankWithCommissionByUser\\",EPayViaPSPWithCommissionByPayer=\\"EPayViaPSPWithCommissionByPayer\\",EPayViaPSPWithCommissionByUser=\\"EPayViaPSPWithCommissionByUser\\",EPayViaWalletWithCommissionByPayer=\\"EPayViaWalletWithCommissionByPayer\\",EPayViaWalletWithCommissionByUser=\\"EPayViaWalletWithCommissionByUser\\",TransferMoney=\\"TransferMoney\\",ChargeWallet=\\"ChargeWallet\\",ServiceBill=\\"ServiceBill\\",ServiceMobileCharge=\\"ServiceMobileCharge\\",POSViaBank=\\"POSViaBank\\",POSViaWallet=\\"POSViaWallet\\",ShareAndBlockRequest=\\"ShareAndBlockRequest\\",ShareRequest=\\"ShareRequest\\",SettlementAuto=\\"SettlementAuto\\",SettlementManual=\\"SettlementManual\\",SettlementSuspected=\\"SettlementSuspected\\",GroupTransferMoney=\\"GroupTransferMoney\\",ShareAndUnblock=\\"ShareAndUnblock\\",RefundWithSystemPayer=\\"RefundWithSystemPayer\\",RefundWithAnonymousPayer=\\"RefundWithAnonymousPayer\\",PayCommand=\\"PayCommand\\",GiftForReferrer=\\"GiftForReferrer\\",GiftForNoCommissionRemain=\\"GiftForNoCommissionRemain\\",Sepid=\\"Sepid\\",BatchTransferItem=\\"BatchTransferItem\\",AbstractProviderSynchronization=\\"AbstractProviderSynchronization\\",BlockchainWithdrawInternalTransfer=\\"BlockchainWithdrawInternalTransfer\\",BlockchainWithdrawUserWallet=\\"BlockchainWithdrawUserWallet\\",BlockchainIncomingTransaction=\\"BlockchainIncomingTransaction\\",BlockchainWithdrawUserWalletOnChain=\\"BlockchainWithdrawUserWalletOnChain\\"}
+        
+        
+        export type WalletDetailApiModel =  & (WalletDisplayApiModel & {\\"notificationEnabled\\": boolean;
+/**
+ * 
+ * - Format: int32
+ */
+\\"permittedSubuserCount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"posPaidCount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"posScanCount\\": number;\\"accountQrCodeUrl\\"?: string;\\"actionPolicies\\"?: CommissionPolicyApiModel[];\\"posLinkUrl\\"?: string;})
+        
+        
+        export interface WalletDisplayApiModel {\\"automaticSettlement\\": boolean;\\"getComissionFromPayer\\": boolean;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"isActive\\": boolean;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"realBalance\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"totalBalance\\": number;\\"directUserBankAccountNumber\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"directUserBankBankId\\"?: number;\\"directUserBankBankName\\"?: string;\\"directUserBankShebaNumber\\"?: string;\\"intermediateUserBankAccountNumber\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"intermediateUserBankBankId\\"?: number;\\"intermediateUserBankBankName\\"?: string;\\"intermediateUserBankShebaNumber\\"?: string;\\"number\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"relatedUserAccountIndex\\"?: number;\\"title\\"?: string;}
+        
+        
+        export interface WalletReceiptApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionAmount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDate\\": string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"payerAccountId\\": number;\\"callbackUrl\\"?: string;\\"creatorUserAvatarUrl\\"?: string;\\"creatorUserDisplayName\\"?: string;\\"description\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"operationId\\"?: number;\\"payerAccountName\\"?: string;\\"payerAccountNumber\\"?: string;\\"sharerUrl\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"targetAccountId\\"?: number;\\"targetAccountNumber\\"?: string;\\"targetUserAvatarUrl\\"?: string;\\"targetUserDisplayName\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"voucherId\\"?: number;}
+        
+        
+        export enum WorkspaceType {User=\\"User\\",SubUser=\\"SubUser\\"}
+        "
+`;

--- a/__tests__/main/__snapshots__/includes.test.mjs.snap
+++ b/__tests__/main/__snapshots__/includes.test.mjs.snap
@@ -1,0 +1,13652 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`only includes get methods generate Code 1`] = `
+"
+//@ts-nocheck
+/**
+* AUTO_GENERATED Do not change this file directly, use config.ts file instead
+*
+* @version 6
+*/
+
+import type { AxiosRequestConfig } from \\"axios\\";
+import type { SwaggerResponse } from \\"./config\\";
+import { Http } from \\"./httpRequest\\";
+//@ts-ignore
+import qs from \\"qs\\";
+import type { GetBusinessUserConnectionQueryParams, GetBusinessUserConnectionActiveQueryParams, GetBusinessUserConnectionConnectionIdEpayQueryParams, GetEpayRequestQueryParams, GetEpayRequestExcelQueryParams, GetEpayRequestForMeQueryParams, GetEpayRequestUserWalletIdCommissionQueryParams, GetEpayRequestCountQueryParams, GetEpayRequestReportQueryParams, GetEpayRequestForMeCountQueryParams, GetEpayRequestForMeReportQueryParams, GetEpayRequestPosQrAccountNumberQueryParams, GetGroupTransferCommissionQueryParams, GetIntegrationQueryParams, GetKpiLastQueryParams, GetKpiCurrentQueryParams, GetKpiQueryParams, GetNotificationUnreadQueryParams, GetPosAccountNumberQueryParams, GetResellerUserIntroducedQueryParams, GetResellerUserDashboardCommissionSumQueryParams, GetResellerUserDashboardCommissionReportQueryParams, GetResellerUserDashboardLinksCountQueryParams, GetResellerUserDashboardLinksReportQueryParams, GetResellerUserDashboardLinksPaidCountQueryParams, GetResellerUserDashboardLinksPaidReportQueryParams, GetResellerUserDashboardTransactionsCountQueryParams, GetResellerUserDashboardTransactionsReportQueryParams, GetResellerUserDashboardIntroducedCountQueryParams, GetResellerUserDashboardIntroducedReportQueryParams, GetTransactionQueryParams, GetTransactionExcelQueryParams, GetTransactionReportQueryParams, GetTransactionReportAllQueryParams, GetTransferSearchQueryParams, GetTransferRecentQueryParams, GetTransferUserWalletIdCommissionQueryParams, GetUserWalletAccountNumberQrcodeQueryParams, GetUserWalletUserWalletIdSettlementRequestComissionQueryParams, GetUserWalletUserWalletIdEpayRequestComissionQueryParams, GetUserWalletSearchQueryParams, GetUserWalletUserWalletIdTransferMoneyCommissionQueryParams, BankApiModel, BusinessCategoryApiModel, SubUserConnectionApiModel, SubUserPermissionApiModel, SubUserActivityApiModel, EpayRequestApiModel, EpayRequestForUserQuery, EpayRequestDetailApiModel, ContactApiModel, CommissionAmountApiModel, UserMinimalDto, EpayRequestPublicInfoApiModel, WalletReceiptApiModel, AggregationApiModel, ReportApiModel, DriverInfoResult, KpiResult, ImportantActionApiModel, NotificationApiModel, UnreadNotificationCountApiModel, PluginApiModel, PosLandingPageApiModel, BankReceiptApiModel, ResellerApiModel, ReselledUserFilterData, ReselledUserApiModel, ReselledUserActivityApiModel, DateReportApiModelOfDecimal, DateReportApiModelOfInteger, SubDomainApiModel, BusinessUserConnectionApiModel, SubUserAccountDetailQuery, TransactionApiModel, AllTransactionsReportApiModel, AccountInfoApiModel, TransferMoneyApiModel, UserBankApiModel, UserBankDetailApiModel, UserDetailQuery, UserMeQuery, UserWorkspaceQuery, UserIdentityRequestQuery, UpgradeToBusinessApiModel, SubUserInvitationApiModel, UserPluginDetailApiModel, WalletDisplayApiModel, WalletDetailApiModel, AccountBalanceApiModel, AccountPermittedSubUserQuery,}  from \\"./types\\"
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const __DEV__ = process.env.NODE_ENV !== \\"production\\";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function overrideConfig(
+  config?: AxiosRequestConfig,
+  configOverride?: AxiosRequestConfig,
+): AxiosRequestConfig {
+  return {
+    ...config,
+    ...configOverride,
+    headers: {
+      ...config?.headers,
+      ...configOverride?.headers,
+    },
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function template(path: string, obj: { [x: string]: any } = {}) {
+    Object.keys(obj).forEach((key) => {
+      const re = new RegExp(\`{\${key}}\`, \\"i\\");
+      path = path.replace(re, obj[key]);
+    });
+
+    return path;
+}
+
+function isFormData(obj: any) {
+  // This checks for the append method which should exist on FormData instances
+  return (
+    (typeof obj === \\"object\\" &&
+      typeof obj.append === \\"function\\" &&
+      obj[Symbol.toStringTag] === undefined) ||
+    obj[Symbol.toStringTag] === \\"FormData\\"
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function objToForm(requestBody: object) {
+  if (isFormData(requestBody)) {
+    return requestBody;
+  }
+  const formData = new FormData();
+
+  Object.entries(requestBody).forEach(([key, value]) => {
+    value && formData.append(key, value);
+  });
+
+  return formData;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function objToUrlencoded(requestBody: object) {
+  return qs.stringify(requestBody)
+}
+
+export const getAccessUserWalletIdLogicalAction = (
+    userWalletId: number,logicalAction: \\"EpayRequest\\" | \\"TransferMoney\\" | \\"AccountChargeRequest\\" | \\"ServiceBill\\" | \\"ServiceMobileCharge\\" | \\"POS\\" | \\"ShareAndBlockRequest\\" | \\"ShareRequest\\" | \\"Settlement\\" | \\"GroupTransferMoney\\" | \\"ShareAndUnblock\\" | \\"Refund\\" | \\"PayCommand\\" | \\"Gift\\" | \\"TaxiFairPayment\\" | \\"HitoBitFee\\",configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<boolean>> => {
+  
+  return Http.getRequest(
+    template(getAccessUserWalletIdLogicalAction.key,{userWalletId,logicalAction,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getAccessUserWalletIdLogicalAction.key = \\"/Access/{userWalletId}/{logicalAction}\\";
+
+
+/**
+ * 
+ * Get available banks
+ */
+export const getBank = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<BankApiModel[]>> => {
+  
+  return Http.getRequest(
+    getBank.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBank.key = \\"/Bank\\";
+
+
+/**
+ * 
+ * Get Business categories
+ */
+export const getBusinessUserCategory = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<BusinessCategoryApiModel[]>> => {
+  
+  return Http.getRequest(
+    getBusinessUserCategory.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBusinessUserCategory.key = \\"/BusinessUser/category\\";
+
+
+/**
+ * 
+ * Get the connections
+[Feature just allowed for the business users]
+ */
+export const getBusinessUserConnection = (
+    queryParams?: GetBusinessUserConnectionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<SubUserConnectionApiModel[]>> => {
+  
+  return Http.getRequest(
+    getBusinessUserConnection.key,
+    queryParams,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBusinessUserConnection.key = \\"/BusinessUser/connection\\";
+
+
+/**
+ * 
+ * Get active connections ordered by Transactions count
+[Feature just allowed for the business users]
+ */
+export const getBusinessUserConnectionActive = (
+    queryParams?: GetBusinessUserConnectionActiveQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<SubUserConnectionApiModel[]>> => {
+  
+  return Http.getRequest(
+    getBusinessUserConnectionActive.key,
+    queryParams,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBusinessUserConnectionActive.key = \\"/BusinessUser/connection/active\\";
+
+
+/**
+ * 
+ * Get the connection detail
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const getBusinessUserConnectionConnectionId = (
+    
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubUserConnectionApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getBusinessUserConnectionConnectionId.key,{connectionId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBusinessUserConnectionConnectionId.key = \\"/BusinessUser/connection/{connectionId}\\";
+
+
+/**
+ * 
+ * Get the connection amounts report
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const getBusinessUserConnectionConnectionIdActivity = (
+    
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubUserActivityApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getBusinessUserConnectionConnectionIdActivity.key,{connectionId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBusinessUserConnectionConnectionIdActivity.key = \\"/BusinessUser/connection/{connectionId}/activity\\";
+
+export const getBusinessUserConnectionConnectionIdEpay = (
+    connectionId: number,queryParams?: GetBusinessUserConnectionConnectionIdEpayQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<EpayRequestApiModel[]>> => {
+  
+  return Http.getRequest(
+    template(getBusinessUserConnectionConnectionIdEpay.key,{connectionId,}),
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBusinessUserConnectionConnectionIdEpay.key = \\"/BusinessUser/connection/{connectionId}/epay\\";
+
+
+/**
+ * 
+ * Get sub user permissions for accounts
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const getBusinessUserConnectionConnectionIdPermission = (
+    
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<SubUserPermissionApiModel[]>> => {
+  
+  return Http.getRequest(
+    template(getBusinessUserConnectionConnectionIdPermission.key,{connectionId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBusinessUserConnectionConnectionIdPermission.key = \\"/BusinessUser/connection/{connectionId}/permission\\";
+
+export const getEpayRequest = (
+    queryParams?: GetEpayRequestQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<EpayRequestApiModel[]>> => {
+  
+  return Http.getRequest(
+    getEpayRequest.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequest.key = \\"/EpayRequest\\";
+
+export const getEpayRequestAudiencesRecent = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<ContactApiModel[]>> => {
+  
+  return Http.getRequest(
+    getEpayRequestAudiencesRecent.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestAudiencesRecent.key = \\"/EpayRequest/audiences/recent\\";
+
+export const getEpayRequestCount = (
+    queryParams?: GetEpayRequestCountQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AggregationApiModel)>> => {
+  
+  return Http.getRequest(
+    getEpayRequestCount.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestCount.key = \\"/EpayRequest/count\\";
+
+
+/**
+ * 
+ * Get epay request detail based on Id
+ */
+export const getEpayRequestEpayId = (
+    
+/**
+ * 
+ * EpayRequest's Id
+ */
+epayId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (EpayRequestDetailApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getEpayRequestEpayId.key,{epayId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestEpayId.key = \\"/EpayRequest/{epayId}\\";
+
+export const getEpayRequestEpayTokenDetail = (
+    epayToken: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (EpayRequestPublicInfoApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getEpayRequestEpayTokenDetail.key,{epayToken,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestEpayTokenDetail.key = \\"/EpayRequest/{epayToken}/detail\\";
+
+
+/**
+ * 
+ * Get QR code image file for epay request
+ */
+export const getEpayRequestEpayTokenQrcode = (
+    
+/**
+ * 
+ * epay request token
+ */
+epayToken: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    template(getEpayRequestEpayTokenQrcode.key,{epayToken,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestEpayTokenQrcode.key = \\"/EpayRequest/{epayToken}/qrcode\\";
+
+export const getEpayRequestExcel = (
+    queryParams?: GetEpayRequestExcelQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    getEpayRequestExcel.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestExcel.key = \\"/EpayRequest/excel\\";
+
+
+/**
+ * 
+ * Get pay requests that the user is one of its audiences.
+[Feature is not allowed for sub users]
+[Needs secure login]
+ */
+export const getEpayRequestForMe = (
+    queryParams?: GetEpayRequestForMeQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<EpayRequestForUserQuery[]>> => {
+  
+  return Http.getRequest(
+    getEpayRequestForMe.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestForMe.key = \\"/EpayRequest/forMe\\";
+
+export const getEpayRequestForMeCount = (
+    queryParams?: GetEpayRequestForMeCountQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AggregationApiModel)>> => {
+  
+  return Http.getRequest(
+    getEpayRequestForMeCount.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestForMeCount.key = \\"/EpayRequest/forMe/count\\";
+
+export const getEpayRequestForMeReport = (
+    queryParams?: GetEpayRequestForMeReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<ReportApiModel[]>> => {
+  
+  return Http.getRequest(
+    getEpayRequestForMeReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestForMeReport.key = \\"/EpayRequest/forMe/report\\";
+
+
+/**
+ * 
+ * [Deprecated, use 'account/{accountNumber}/qrcode' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getEpayRequestPosQrAccountNumber = (
+    accountNumber: string,queryParams?: GetEpayRequestPosQrAccountNumberQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getEpayRequestPosQrAccountNumber\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    template(getEpayRequestPosQrAccountNumber.key,{accountNumber,}),
+    queryParams,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestPosQrAccountNumber.key = \\"/EpayRequest/pos/Qr/{accountNumber}\\";
+
+export const getEpayRequestReport = (
+    queryParams?: GetEpayRequestReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<ReportApiModel[]>> => {
+  
+  return Http.getRequest(
+    getEpayRequestReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestReport.key = \\"/EpayRequest/report\\";
+
+
+/**
+ * 
+ * Get comission amount for epay request amount
+ */
+export const getEpayRequestUserWalletIdCommission = (
+    userWalletId: number,queryParams?: GetEpayRequestUserWalletIdCommissionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (CommissionAmountApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getEpayRequestUserWalletIdCommission.key,{userWalletId,}),
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestUserWalletIdCommission.key = \\"/EpayRequest/{userWalletId}/commission\\";
+
+export const getEpayRequestUserWalletIdCreators = (
+    userWalletId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<UserMinimalDto[]>> => {
+  
+  return Http.getRequest(
+    template(getEpayRequestUserWalletIdCreators.key,{userWalletId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestUserWalletIdCreators.key = \\"/EpayRequest/{userWalletId}/creators\\";
+
+export const getError = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    getError.key,
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getError.key = \\"/error\\";
+
+export const getErrorLocal = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    getErrorLocal.key,
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getErrorLocal.key = \\"/error/local\\";
+
+export const getErrorStatusCode = (
+    code: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    template(getErrorStatusCode.key,{code,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getErrorStatusCode.key = \\"/error/status/{code}\\";
+
+
+/**
+ * 
+ * Download a file.
+ */
+export const getFileFileGuid = (
+    
+/**
+ * 
+ * file unique id
+ */
+fileGuid: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    template(getFileFileGuid.key,{fileGuid,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getFileFileGuid.key = \\"/File/{fileGuid}\\";
+
+export const getGroupTransferCommission = (
+    queryParams?: GetGroupTransferCommissionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (CommissionAmountApiModel)>> => {
+  
+  return Http.getRequest(
+    getGroupTransferCommission.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getGroupTransferCommission.key = \\"/GroupTransfer/commission\\";
+
+
+/**
+ * 
+ * Get detailed driver,taxi and fair amount information
+ */
+export const getIntegration = (
+    queryParams?: GetIntegrationQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (DriverInfoResult)>> => {
+  
+  return Http.getRequest(
+    getIntegration.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT4,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getIntegration.key = \\"/Integration\\";
+
+export const getKpi = (
+    queryParams?: GetKpiQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<KpiResult[]>> => {
+  
+  return Http.getRequest(
+    getKpi.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getKpi.key = \\"/Kpi\\";
+
+export const getKpiCurrent = (
+    queryParams?: GetKpiCurrentQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<KpiResult[]>> => {
+  
+  return Http.getRequest(
+    getKpiCurrent.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getKpiCurrent.key = \\"/Kpi/Current\\";
+
+export const getKpiLast = (
+    queryParams?: GetKpiLastQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<KpiResult[]>> => {
+  
+  return Http.getRequest(
+    getKpiLast.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getKpiLast.key = \\"/Kpi/Last\\";
+
+
+/**
+ * 
+ * Get all Important Actions of current user.
+ */
+export const getNotificationIa = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<ImportantActionApiModel[]>> => {
+  
+  return Http.getRequest(
+    getNotificationIa.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getNotificationIa.key = \\"/Notification/ia\\";
+
+
+/**
+ * 
+ * Get Notifications of current user.
+Maximum 99 items will be returned.
+ */
+export const getNotificationNotif = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<NotificationApiModel[]>> => {
+  
+  return Http.getRequest(
+    getNotificationNotif.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getNotificationNotif.key = \\"/Notification/notif\\";
+
+export const getNotificationUnread = (
+    queryParams?: GetNotificationUnreadQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<UnreadNotificationCountApiModel[]>> => {
+  
+  return Http.getRequest(
+    getNotificationUnread.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getNotificationUnread.key = \\"/Notification/unread\\";
+
+export const getPluginPluginId = (
+    pluginId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (PluginApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getPluginPluginId.key,{pluginId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getPluginPluginId.key = \\"/Plugin/{pluginId}\\";
+
+
+/**
+ * 
+ * Get epay request detail
+ */
+export const getPosAccountNumber = (
+    
+/**
+ * 
+ * Account Number
+ */
+accountNumber: string,queryParams?: GetPosAccountNumberQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (PosLandingPageApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getPosAccountNumber.key,{accountNumber,}),
+    queryParams,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getPosAccountNumber.key = \\"/Pos/{accountNumber}\\";
+
+
+/**
+ * 
+ * Get bank receipt by EPayTry id
+[For anonymous users]
+ */
+export const getReceiptBankEpayTryId = (
+    
+/**
+ * 
+ * EpayTry's id to get receipt for
+ */
+epayTryId: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (BankReceiptApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getReceiptBankEpayTryId.key,{epayTryId,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getReceiptBankEpayTryId.key = \\"/Receipt/bank/{epayTryId}\\";
+
+
+/**
+ * 
+ * Get bank receipt by EPayRequest token
+[For anonymous users]
+[Deprecated, use 'receipt/bank/{epayTryId}' and 'receipt/bank/{epayTryId}' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getReceiptEpayToken = (
+    
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (BankReceiptApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getReceiptEpayToken\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    template(getReceiptEpayToken.key,{epayToken,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getReceiptEpayToken.key = \\"/Receipt/{epayToken}\\";
+
+
+/**
+ * 
+ * Get wallet receipt by EPayRequest token
+[For anonymous users]
+ */
+export const getReceiptWalletEpayToken = (
+    
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (WalletReceiptApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getReceiptWalletEpayToken.key,{epayToken,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getReceiptWalletEpayToken.key = \\"/Receipt/wallet/{epayToken}\\";
+
+
+/**
+ * 
+ * Get the Resellership info of current Reseller user
+[Feature just allowed for Resellers]
+ */
+export const getResellerUser = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (ResellerApiModel)>> => {
+  
+  return Http.getRequest(
+    getResellerUser.key,
+    undefined,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUser.key = \\"/ResellerUser\\";
+
+
+/**
+ * 
+ * Get the time-based report of commissions paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardCommissionReport = (
+    queryParams?: GetResellerUserDashboardCommissionReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<DateReportApiModelOfDecimal[]>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardCommissionReport\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardCommissionReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardCommissionReport.key = \\"/ResellerUser/dashboard/commission/report\\";
+
+
+/**
+ * 
+ * Get sum of all commissions paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardCommissionSum = (
+    queryParams?: GetResellerUserDashboardCommissionSumQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AggregationApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardCommissionSum\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardCommissionSum.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardCommissionSum.key = \\"/ResellerUser/dashboard/commission/sum\\";
+
+
+/**
+ * 
+ * Get count of all users reselled by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardIntroducedCount = (
+    queryParams?: GetResellerUserDashboardIntroducedCountQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AggregationApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardIntroducedCount\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardIntroducedCount.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardIntroducedCount.key = \\"/ResellerUser/dashboard/introduced/count\\";
+
+
+/**
+ * 
+ * Get time-based report of users reselled by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardIntroducedReport = (
+    queryParams?: GetResellerUserDashboardIntroducedReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<DateReportApiModelOfInteger[]>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardIntroducedReport\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardIntroducedReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardIntroducedReport.key = \\"/ResellerUser/dashboard/introduced/report\\";
+
+
+/**
+ * 
+ * Get count of all links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardLinksCount = (
+    queryParams?: GetResellerUserDashboardLinksCountQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AggregationApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardLinksCount\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardLinksCount.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardLinksCount.key = \\"/ResellerUser/dashboard/links/count\\";
+
+
+/**
+ * 
+ * Get count of all paid links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardLinksPaidCount = (
+    queryParams?: GetResellerUserDashboardLinksPaidCountQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AggregationApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardLinksPaidCount\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardLinksPaidCount.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardLinksPaidCount.key = \\"/ResellerUser/dashboard/links/paid/count\\";
+
+
+/**
+ * 
+ * Get time-based report of paid links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardLinksPaidReport = (
+    queryParams?: GetResellerUserDashboardLinksPaidReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<DateReportApiModelOfInteger[]>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardLinksPaidReport\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardLinksPaidReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardLinksPaidReport.key = \\"/ResellerUser/dashboard/links/paid/report\\";
+
+
+/**
+ * 
+ * Get time-based report of links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardLinksReport = (
+    queryParams?: GetResellerUserDashboardLinksReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<DateReportApiModelOfInteger[]>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardLinksReport\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardLinksReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardLinksReport.key = \\"/ResellerUser/dashboard/links/report\\";
+
+
+/**
+ * 
+ * Get count of all commission transactions, paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardTransactionsCount = (
+    queryParams?: GetResellerUserDashboardTransactionsCountQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AggregationApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardTransactionsCount\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardTransactionsCount.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardTransactionsCount.key = \\"/ResellerUser/dashboard/transactions/count\\";
+
+
+/**
+ * 
+ * Get time-based report of commission transactions, paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getResellerUserDashboardTransactionsReport = (
+    queryParams?: GetResellerUserDashboardTransactionsReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<DateReportApiModelOfInteger[]>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getResellerUserDashboardTransactionsReport\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getResellerUserDashboardTransactionsReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserDashboardTransactionsReport.key = \\"/ResellerUser/dashboard/transactions/report\\";
+
+
+/**
+ * 
+ * Get the Users Introduced by current Reseller user
+[Feature just allowed for Resellers]
+ */
+export const getResellerUserIntroduced = (
+    queryParams?: GetResellerUserIntroducedQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<ReselledUserApiModel[]>> => {
+  
+  return Http.getRequest(
+    getResellerUserIntroduced.key,
+    queryParams,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserIntroduced.key = \\"/ResellerUser/introduced\\";
+
+
+/**
+ * 
+ * Get filter data items to populate DropDowns
+[Feature just allowed for Resellers]
+ */
+export const getResellerUserIntroducedFilterData = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (ReselledUserFilterData)>> => {
+  
+  return Http.getRequest(
+    getResellerUserIntroducedFilterData.key,
+    undefined,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserIntroducedFilterData.key = \\"/ResellerUser/introduced/filterData\\";
+
+
+/**
+ * 
+ * Get the User activity
+[Feature just allowed for Resellers]
+ */
+export const getResellerUserIntroducedUserIdActivity = (
+    userId: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (ReselledUserActivityApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getResellerUserIntroducedUserIdActivity.key,{userId,}),
+    undefined,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getResellerUserIntroducedUserIdActivity.key = \\"/ResellerUser/introduced/{userId}/activity\\";
+
+
+/**
+ * 
+ * Get the SubDomain of current Reseller user
+[Feature just allowed for Resellers]
+ */
+export const getSubDomain = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubDomainApiModel)>> => {
+  
+  return Http.getRequest(
+    getSubDomain.key,
+    undefined,
+    undefined,
+    _CONSTANT5,
+    overrideConfig(_CONSTANT4,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getSubDomain.key = \\"/SubDomain\\";
+
+
+/**
+ * 
+ * Get info of a SubDomain by it's address.
+ */
+export const getSubDomainSubDomainAddress = (
+    
+/**
+ * 
+ * The SubDomain part of the url.
+            
+ */
+subDomainAddress: string,headerParams?: {
+/**
+ * 
+ * - Format: guid
+ */
+\\"clientId\\": string;},configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubDomainApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getSubDomainSubDomainAddress.key,{subDomainAddress,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig({
+              headers:{
+                ..._CONSTANT6,
+                ...headerParams,
+              },
+            },
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getSubDomainSubDomainAddress.key = \\"/SubDomain/{subDomainAddress}\\";
+
+
+/**
+ * 
+ * Get permission details of an Account
+[Feature just allowed for SubUsers]
+ */
+export const getSubUserAccountUserWalletId = (
+    userWalletId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubUserAccountDetailQuery)>> => {
+  
+  return Http.getRequest(
+    template(getSubUserAccountUserWalletId.key,{userWalletId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getSubUserAccountUserWalletId.key = \\"/SubUser/account/{userWalletId}\\";
+
+
+/**
+ * 
+ * Get the connections
+[Feature just allowed for SubUsers]
+[Deprecated. use 'user/connection' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getSubUserConnection = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<BusinessUserConnectionApiModel[]>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getSubUserConnection\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getSubUserConnection.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getSubUserConnection.key = \\"/SubUser/connection\\";
+
+export const getTransaction = (
+    queryParams?: GetTransactionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<TransactionApiModel[]>> => {
+  
+  return Http.getRequest(
+    getTransaction.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransaction.key = \\"/Transaction\\";
+
+export const getTransactionExcel = (
+    queryParams?: GetTransactionExcelQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    getTransactionExcel.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransactionExcel.key = \\"/Transaction/excel\\";
+
+
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getTransactionReport = (
+    queryParams?: GetTransactionReportQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<ReportApiModel[]>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getTransactionReport\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getTransactionReport.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransactionReport.key = \\"/Transaction/report\\";
+
+
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getTransactionReportAll = (
+    queryParams?: GetTransactionReportAllQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AllTransactionsReportApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getTransactionReportAll\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getTransactionReportAll.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransactionReportAll.key = \\"/Transaction/report/all\\";
+
+
+/**
+ * 
+ * Get a Transaction by it's Id
+[Needs secure login]
+ */
+export const getTransactionTransactionId = (
+    transactionId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (TransactionApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getTransactionTransactionId.key,{transactionId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransactionTransactionId.key = \\"/Transaction/{transactionId}\\";
+
+
+/**
+ * 
+ * Get recent money transfers
+ */
+export const getTransferRecent = (
+    queryParams?: GetTransferRecentQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<TransferMoneyApiModel[]>> => {
+  
+  return Http.getRequest(
+    getTransferRecent.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransferRecent.key = \\"/Transfer/recent\\";
+
+export const getTransferSearch = (
+    queryParams?: GetTransferSearchQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AccountInfoApiModel)>> => {
+  
+  return Http.getRequest(
+    getTransferSearch.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransferSearch.key = \\"/Transfer/search\\";
+
+
+/**
+ * 
+ * Get commission amount for transfer money amount
+ */
+export const getTransferUserWalletIdCommission = (
+    userWalletId: number,queryParams?: GetTransferUserWalletIdCommissionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (CommissionAmountApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getTransferUserWalletIdCommission.key,{userWalletId,}),
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransferUserWalletIdCommission.key = \\"/Transfer/{userWalletId}/commission\\";
+
+
+/**
+ * 
+ * Get [normal/sub/business] user profile detail
+ */
+export const getUser = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (UserDetailQuery)>> => {
+  
+  return Http.getRequest(
+    getUser.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUser.key = \\"/User\\";
+
+
+/**
+ * 
+ * Get user banks
+[Feature is not allowed for sub users.]
+ */
+export const getUserBank = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<UserBankApiModel[]>> => {
+  
+  return Http.getRequest(
+    getUserBank.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserBank.key = \\"/UserBank\\";
+
+
+/**
+ * 
+ * Get available user banks
+[Feature is not allowed for sub users.]
+ */
+export const getUserBankReady = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<UserBankApiModel[]>> => {
+  
+  return Http.getRequest(
+    getUserBankReady.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserBankReady.key = \\"/UserBank/ready\\";
+
+
+/**
+ * 
+ * get user bank detail
+[Needs secure login]
+ */
+export const getUserBankUserBankId = (
+    
+/**
+ * 
+ * User bank id
+ */
+userBankId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (UserBankDetailApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getUserBankUserBankId.key,{userBankId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserBankUserBankId.key = \\"/UserBank/{userBankId}\\";
+
+
+/**
+ * 
+ * Get the connections [Feature is allowed for normal users noly]
+ */
+export const getUserConnection = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<BusinessUserConnectionApiModel[]>> => {
+  
+  return Http.getRequest(
+    getUserConnection.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserConnection.key = \\"/User/connection\\";
+
+export const getUserContactInput = (
+    input: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (ContactApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getUserContactInput.key,{input,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserContactInput.key = \\"/User/contact/{input}\\";
+
+
+/**
+ * 
+ * Get last national id verification request [Feature is not allowed for sub users]
+ */
+export const getUserIdentityRequest = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (UserIdentityRequestQuery)>> => {
+  
+  return Http.getRequest(
+    getUserIdentityRequest.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserIdentityRequest.key = \\"/User/identityRequest\\";
+
+
+/**
+ * 
+ * Get business user invitations for me [Feature is not allowed for sub users]
+ */
+export const getUserInvitation = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<SubUserInvitationApiModel[]>> => {
+  
+  return Http.getRequest(
+    getUserInvitation.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserInvitation.key = \\"/User/invitation\\";
+
+
+/**
+ * 
+ * Get business user invitations for me [Feature is not allowed for sub users]
+ */
+export const getUserInvitationInvitationToken = (
+    invitationToken: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubUserInvitationApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getUserInvitationInvitationToken.key,{invitationToken,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserInvitationInvitationToken.key = \\"/User/invitation/{invitationToken}\\";
+
+
+/**
+ * 
+ * Get user profile summary
+ */
+export const getUserMe = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (UserMeQuery)>> => {
+  
+  return Http.getRequest(
+    getUserMe.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserMe.key = \\"/User/me\\";
+
+export const getUserPlugin = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<UserPluginDetailApiModel[]>> => {
+  
+  return Http.getRequest(
+    getUserPlugin.key,
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserPlugin.key = \\"/UserPlugin\\";
+
+
+/**
+ * 
+ * Get Last Request for upgrade account to the business [Feature is allowed for normal users only]
+ */
+export const getUserUpgradeToBusinessRequest = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (UpgradeToBusinessApiModel)>> => {
+  
+  return Http.getRequest(
+    getUserUpgradeToBusinessRequest.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserUpgradeToBusinessRequest.key = \\"/User/upgradeToBusinessRequest\\";
+
+export const getUserWallet = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<WalletDisplayApiModel[]>> => {
+  
+  return Http.getRequest(
+    getUserWallet.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWallet.key = \\"/UserWallet\\";
+
+export const getUserWalletAccountNumberQrcode = (
+    accountNumber: string,queryParams?: GetUserWalletAccountNumberQrcodeQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.getRequest(
+    template(getUserWalletAccountNumberQrcode.key,{accountNumber,}),
+    queryParams,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletAccountNumberQrcode.key = \\"/UserWallet/{accountNumber}/qrcode\\";
+
+
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getUserWalletSearch = (
+    queryParams?: GetUserWalletSearchQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AccountInfoApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getUserWalletSearch\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    getUserWalletSearch.key,
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletSearch.key = \\"/UserWallet/search\\";
+
+export const getUserWalletUserWalletId = (
+    userWalletId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (WalletDetailApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getUserWalletUserWalletId.key,{userWalletId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletUserWalletId.key = \\"/UserWallet/{userWalletId}\\";
+
+
+/**
+ * 
+ * Get user account balance
+ */
+export const getUserWalletUserWalletIdBalance = (
+    userWalletId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (AccountBalanceApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getUserWalletUserWalletIdBalance.key,{userWalletId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletUserWalletIdBalance.key = \\"/UserWallet/{userWalletId}/balance\\";
+
+
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getUserWalletUserWalletIdEpayRequestComission = (
+    userWalletId: number,queryParams?: GetUserWalletUserWalletIdEpayRequestComissionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (CommissionAmountApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getUserWalletUserWalletIdEpayRequestComission\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    template(getUserWalletUserWalletIdEpayRequestComission.key,{userWalletId,}),
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletUserWalletIdEpayRequestComission.key = \\"/UserWallet/{userWalletId}/epayRequest/comission\\";
+
+export const getUserWalletUserWalletIdPermittedsubusers = (
+    userWalletId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<AccountPermittedSubUserQuery[]>> => {
+  
+  return Http.getRequest(
+    template(getUserWalletUserWalletIdPermittedsubusers.key,{userWalletId,}),
+    undefined,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletUserWalletIdPermittedsubusers.key = \\"/UserWallet/{userWalletId}/permittedsubusers\\";
+
+export const getUserWalletUserWalletIdSettlementRequestComission = (
+    userWalletId: number,queryParams?: GetUserWalletUserWalletIdSettlementRequestComissionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (CommissionAmountApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getUserWalletUserWalletIdSettlementRequestComission.key,{userWalletId,}),
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletUserWalletIdSettlementRequestComission.key = \\"/UserWallet/{userWalletId}/settlementRequest/comission\\";
+
+
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const getUserWalletUserWalletIdTransferMoneyCommission = (
+    userWalletId: number,queryParams?: GetUserWalletUserWalletIdTransferMoneyCommissionQueryParams,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (CommissionAmountApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"getUserWalletUserWalletIdTransferMoneyCommission\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.getRequest(
+    template(getUserWalletUserWalletIdTransferMoneyCommission.key,{userWalletId,}),
+    queryParams,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletUserWalletIdTransferMoneyCommission.key = \\"/UserWallet/{userWalletId}/transferMoney/commission\\";
+
+
+/**
+ * 
+ * Get user work spaces
+ */
+export const getUserWorkspace = (
+    configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<UserWorkspaceQuery[]>> => {
+  
+  return Http.getRequest(
+    getUserWorkspace.key,
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWorkspace.key = \\"/User/workspace\\";
+export const _CONSTANT0 = {
+              headers: {
+                \\"Content-Type\\": \\"application/json\\",
+                Accept: \\"application/json\\",
+              },
+            };export const _CONSTANT1 = [{\\"bearer\\":[]}];export const _CONSTANT2 = [{\\"bearer\\":[\\"Business\\"]}];export const _CONSTANT3 = {
+              headers: {
+                \\"Content-Type\\": \\"application/json\\",
+                Accept: \\"*/*\\",
+              },
+            };export const _CONSTANT4 = {
+              headers: {
+                \\"Content-Type\\": \\"application/json\\",
+                Accept: \\"text/plain\\",
+              },
+            };export const _CONSTANT5 = [{\\"bearer\\":[\\"Reseller\\"]}];export const _CONSTANT6 = {
+                  \\"Content-Type\\": \\"application/json\\",
+                  Accept: \\"text/plain\\",
+
+                };"
+`;
+
+exports[`only includes get methods generate hooks 1`] = `
+"
+//@ts-nocheck
+/**
+* AUTO_GENERATED Do not change this file directly, use config.ts file instead
+*
+* @version 6
+*/
+
+
+import { AxiosRequestConfig } from \\"axios\\";
+import {
+  UseQueryOptions,
+  useQuery,
+  useMutation,
+  UseMutationOptions,
+  
+  QueryClient,
+  QueryKey,
+} from \\"@tanstack/react-query\\";
+import { RequestError, SwaggerResponse } from \\"./config\\";
+
+import type { AccountBalanceApiModel, AccountInfoApiModel, AccountPermittedSubUserQuery, AggregationApiModel, AllTransactionsReportApiModel, BankApiModel, BankReceiptApiModel, BusinessCategoryApiModel, BusinessUserConnectionApiModel, CommissionAmountApiModel, ContactApiModel, DateReportApiModelOfDecimal, DateReportApiModelOfInteger, DriverInfoResult, EpayRequestApiModel, EpayRequestDetailApiModel, EpayRequestForUserQuery, EpayRequestPublicInfoApiModel, GetBusinessUserConnectionActiveQueryParams, GetBusinessUserConnectionConnectionIdEpayQueryParams, GetBusinessUserConnectionQueryParams, GetEpayRequestCountQueryParams, GetEpayRequestExcelQueryParams, GetEpayRequestForMeCountQueryParams, GetEpayRequestForMeQueryParams, GetEpayRequestForMeReportQueryParams, GetEpayRequestPosQrAccountNumberQueryParams, GetEpayRequestQueryParams, GetEpayRequestReportQueryParams, GetEpayRequestUserWalletIdCommissionQueryParams, GetGroupTransferCommissionQueryParams, GetIntegrationQueryParams, GetKpiCurrentQueryParams, GetKpiLastQueryParams, GetKpiQueryParams, GetNotificationUnreadQueryParams, GetPosAccountNumberQueryParams, GetResellerUserDashboardCommissionReportQueryParams, GetResellerUserDashboardCommissionSumQueryParams, GetResellerUserDashboardIntroducedCountQueryParams, GetResellerUserDashboardIntroducedReportQueryParams, GetResellerUserDashboardLinksCountQueryParams, GetResellerUserDashboardLinksPaidCountQueryParams, GetResellerUserDashboardLinksPaidReportQueryParams, GetResellerUserDashboardLinksReportQueryParams, GetResellerUserDashboardTransactionsCountQueryParams, GetResellerUserDashboardTransactionsReportQueryParams, GetResellerUserIntroducedQueryParams, GetTransactionExcelQueryParams, GetTransactionQueryParams, GetTransactionReportAllQueryParams, GetTransactionReportQueryParams, GetTransferRecentQueryParams, GetTransferSearchQueryParams, GetTransferUserWalletIdCommissionQueryParams, GetUserWalletAccountNumberQrcodeQueryParams, GetUserWalletSearchQueryParams, GetUserWalletUserWalletIdEpayRequestComissionQueryParams, GetUserWalletUserWalletIdSettlementRequestComissionQueryParams, GetUserWalletUserWalletIdTransferMoneyCommissionQueryParams, ImportantActionApiModel, KpiResult, NotificationApiModel, PluginApiModel, PosLandingPageApiModel, ReportApiModel, ReselledUserActivityApiModel, ReselledUserApiModel, ReselledUserFilterData, ResellerApiModel, SubDomainApiModel, SubUserAccountDetailQuery, SubUserActivityApiModel, SubUserConnectionApiModel, SubUserInvitationApiModel, SubUserPermissionApiModel, TransactionApiModel, TransferMoneyApiModel, UnreadNotificationCountApiModel, UpgradeToBusinessApiModel, UserBankApiModel, UserBankDetailApiModel, UserDetailQuery, UserIdentityRequestQuery, UserMeQuery, UserMinimalDto, UserPluginDetailApiModel, UserWorkspaceQuery, WalletDetailApiModel, WalletDisplayApiModel, WalletReceiptApiModel,}  from \\"./types\\"
+import { getAccessUserWalletIdLogicalAction, getBank, getBusinessUserCategory, getBusinessUserConnection, getBusinessUserConnectionActive, getBusinessUserConnectionConnectionId, getBusinessUserConnectionConnectionIdActivity, getBusinessUserConnectionConnectionIdEpay, getBusinessUserConnectionConnectionIdPermission, getEpayRequest, getEpayRequestAudiencesRecent, getEpayRequestCount, getEpayRequestEpayId, getEpayRequestEpayTokenDetail, getEpayRequestEpayTokenQrcode, getEpayRequestExcel, getEpayRequestForMe, getEpayRequestForMeCount, getEpayRequestForMeReport, getEpayRequestPosQrAccountNumber, getEpayRequestReport, getEpayRequestUserWalletIdCommission, getEpayRequestUserWalletIdCreators, getError, getErrorLocal, getErrorStatusCode, getFileFileGuid, getGroupTransferCommission, getIntegration, getKpi, getKpiCurrent, getKpiLast, getNotificationIa, getNotificationNotif, getNotificationUnread, getPluginPluginId, getPosAccountNumber, getReceiptBankEpayTryId, getReceiptEpayToken, getReceiptWalletEpayToken, getResellerUser, getResellerUserDashboardCommissionReport, getResellerUserDashboardCommissionSum, getResellerUserDashboardIntroducedCount, getResellerUserDashboardIntroducedReport, getResellerUserDashboardLinksCount, getResellerUserDashboardLinksPaidCount, getResellerUserDashboardLinksPaidReport, getResellerUserDashboardLinksReport, getResellerUserDashboardTransactionsCount, getResellerUserDashboardTransactionsReport, getResellerUserIntroduced, getResellerUserIntroducedFilterData, getResellerUserIntroducedUserIdActivity, getSubDomain, getSubDomainSubDomainAddress, getSubUserAccountUserWalletId, getSubUserConnection, getTransaction, getTransactionExcel, getTransactionReport, getTransactionReportAll, getTransactionTransactionId, getTransferRecent, getTransferSearch, getTransferUserWalletIdCommission, getUser, getUserBank, getUserBankReady, getUserBankUserBankId, getUserConnection, getUserContactInput, getUserIdentityRequest, getUserInvitation, getUserInvitationInvitationToken, getUserMe, getUserPlugin, getUserUpgradeToBusinessRequest, getUserWallet, getUserWalletAccountNumberQrcode, getUserWalletSearch, getUserWalletUserWalletId, getUserWalletUserWalletIdBalance, getUserWalletUserWalletIdEpayRequestComission, getUserWalletUserWalletIdPermittedsubusers, getUserWalletUserWalletIdSettlementRequestComission, getUserWalletUserWalletIdTransferMoneyCommission, getUserWorkspace,}  from \\"./services\\"
+
+    export type SwaggerTypescriptMutationDefaultParams<TExtra> = {_extraVariables?:TExtra, configOverride?:AxiosRequestConfig}
+    type SwaggerTypescriptUseQueryOptions<TData> = Omit<UseQueryOptions<SwaggerResponse<TData>,RequestError | Error>,\\"queryKey\\">;
+
+    type SwaggerTypescriptUseMutationOptions<TData, TRequest, TExtra> = UseMutationOptions<
+      SwaggerResponse<TData>,
+      RequestError | Error,
+      TRequest & SwaggerTypescriptMutationDefaultParams<TExtra>
+    >;
+
+    type SwaggerTypescriptUseMutationOptionsVoid<
+      TData,
+      TExtra
+    > = UseMutationOptions<
+      SwaggerResponse<TData>,
+      RequestError | Error,
+      SwaggerTypescriptMutationDefaultParams<TExtra> | void
+    >;  
+    
+      export const useGetAccessUserWalletIdLogicalAction = (
+           userWalletId: number,logicalAction: \\"EpayRequest\\" | \\"TransferMoney\\" | \\"AccountChargeRequest\\" | \\"ServiceBill\\" | \\"ServiceMobileCharge\\" | \\"POS\\" | \\"ShareAndBlockRequest\\" | \\"ShareRequest\\" | \\"Settlement\\" | \\"GroupTransferMoney\\" | \\"ShareAndUnblock\\" | \\"Refund\\" | \\"PayCommand\\" | \\"Gift\\" | \\"TaxiFairPayment\\" | \\"HitoBitFee\\",options?:SwaggerTypescriptUseQueryOptions<boolean>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetAccessUserWalletIdLogicalAction.info( userWalletId,logicalAction,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetAccessUserWalletIdLogicalAction.info = (userWalletId: number,logicalAction: \\"EpayRequest\\" | \\"TransferMoney\\" | \\"AccountChargeRequest\\" | \\"ServiceBill\\" | \\"ServiceMobileCharge\\" | \\"POS\\" | \\"ShareAndBlockRequest\\" | \\"ShareRequest\\" | \\"Settlement\\" | \\"GroupTransferMoney\\" | \\"ShareAndUnblock\\" | \\"Refund\\" | \\"PayCommand\\" | \\"Gift\\" | \\"TaxiFairPayment\\" | \\"HitoBitFee\\",configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getAccessUserWalletIdLogicalAction.key,userWalletId,logicalAction,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getAccessUserWalletIdLogicalAction(
+                   userWalletId,logicalAction,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetAccessUserWalletIdLogicalAction.prefetch = (
+            client: QueryClient,
+            userWalletId: number,logicalAction: \\"EpayRequest\\" | \\"TransferMoney\\" | \\"AccountChargeRequest\\" | \\"ServiceBill\\" | \\"ServiceMobileCharge\\" | \\"POS\\" | \\"ShareAndBlockRequest\\" | \\"ShareRequest\\" | \\"Settlement\\" | \\"GroupTransferMoney\\" | \\"ShareAndUnblock\\" | \\"Refund\\" | \\"PayCommand\\" | \\"Gift\\" | \\"TaxiFairPayment\\" | \\"HitoBitFee\\",options?:SwaggerTypescriptUseQueryOptions<boolean>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetAccessUserWalletIdLogicalAction.info( userWalletId,logicalAction,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get available banks
+ */
+export const useGetBank = (
+           options?:SwaggerTypescriptUseQueryOptions<BankApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBank.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBank.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBank.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getBank(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetBank.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<BankApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBank.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get Business categories
+ */
+export const useGetBusinessUserCategory = (
+           options?:SwaggerTypescriptUseQueryOptions<BusinessCategoryApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBusinessUserCategory.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBusinessUserCategory.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBusinessUserCategory.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getBusinessUserCategory(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetBusinessUserCategory.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<BusinessCategoryApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBusinessUserCategory.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the connections
+[Feature just allowed for the business users]
+ */
+export const useGetBusinessUserConnection = (
+           queryParams?: GetBusinessUserConnectionQueryParams,options?:SwaggerTypescriptUseQueryOptions<SubUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBusinessUserConnection.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBusinessUserConnection.info = (queryParams?: GetBusinessUserConnectionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBusinessUserConnection.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getBusinessUserConnection(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetBusinessUserConnection.prefetch = (
+            client: QueryClient,
+            queryParams?: GetBusinessUserConnectionQueryParams,options?:SwaggerTypescriptUseQueryOptions<SubUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBusinessUserConnection.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get active connections ordered by Transactions count
+[Feature just allowed for the business users]
+ */
+export const useGetBusinessUserConnectionActive = (
+           queryParams?: GetBusinessUserConnectionActiveQueryParams,options?:SwaggerTypescriptUseQueryOptions<SubUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBusinessUserConnectionActive.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBusinessUserConnectionActive.info = (queryParams?: GetBusinessUserConnectionActiveQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBusinessUserConnectionActive.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getBusinessUserConnectionActive(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetBusinessUserConnectionActive.prefetch = (
+            client: QueryClient,
+            queryParams?: GetBusinessUserConnectionActiveQueryParams,options?:SwaggerTypescriptUseQueryOptions<SubUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBusinessUserConnectionActive.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the connection detail
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const useGetBusinessUserConnectionConnectionId = (
+           
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,options?:SwaggerTypescriptUseQueryOptions< & (SubUserConnectionApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBusinessUserConnectionConnectionId.info( connectionId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBusinessUserConnectionConnectionId.info = (
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBusinessUserConnectionConnectionId.key,connectionId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getBusinessUserConnectionConnectionId(
+                   connectionId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetBusinessUserConnectionConnectionId.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,options?:SwaggerTypescriptUseQueryOptions< & (SubUserConnectionApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBusinessUserConnectionConnectionId.info( connectionId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the connection amounts report
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const useGetBusinessUserConnectionConnectionIdActivity = (
+           
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,options?:SwaggerTypescriptUseQueryOptions< & (SubUserActivityApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBusinessUserConnectionConnectionIdActivity.info( connectionId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBusinessUserConnectionConnectionIdActivity.info = (
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBusinessUserConnectionConnectionIdActivity.key,connectionId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getBusinessUserConnectionConnectionIdActivity(
+                   connectionId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetBusinessUserConnectionConnectionIdActivity.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,options?:SwaggerTypescriptUseQueryOptions< & (SubUserActivityApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBusinessUserConnectionConnectionIdActivity.info( connectionId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetBusinessUserConnectionConnectionIdEpay = (
+           connectionId: number,queryParams?: GetBusinessUserConnectionConnectionIdEpayQueryParams,options?:SwaggerTypescriptUseQueryOptions<EpayRequestApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBusinessUserConnectionConnectionIdEpay.info( connectionId,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBusinessUserConnectionConnectionIdEpay.info = (connectionId: number,queryParams?: GetBusinessUserConnectionConnectionIdEpayQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBusinessUserConnectionConnectionIdEpay.key,connectionId,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getBusinessUserConnectionConnectionIdEpay(
+                   connectionId,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetBusinessUserConnectionConnectionIdEpay.prefetch = (
+            client: QueryClient,
+            connectionId: number,queryParams?: GetBusinessUserConnectionConnectionIdEpayQueryParams,options?:SwaggerTypescriptUseQueryOptions<EpayRequestApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBusinessUserConnectionConnectionIdEpay.info( connectionId,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get sub user permissions for accounts
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const useGetBusinessUserConnectionConnectionIdPermission = (
+           
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,options?:SwaggerTypescriptUseQueryOptions<SubUserPermissionApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBusinessUserConnectionConnectionIdPermission.info( connectionId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBusinessUserConnectionConnectionIdPermission.info = (
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBusinessUserConnectionConnectionIdPermission.key,connectionId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getBusinessUserConnectionConnectionIdPermission(
+                   connectionId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetBusinessUserConnectionConnectionIdPermission.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,options?:SwaggerTypescriptUseQueryOptions<SubUserPermissionApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBusinessUserConnectionConnectionIdPermission.info( connectionId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequest = (
+           queryParams?: GetEpayRequestQueryParams,options?:SwaggerTypescriptUseQueryOptions<EpayRequestApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequest.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequest.info = (queryParams?: GetEpayRequestQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequest.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequest(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequest.prefetch = (
+            client: QueryClient,
+            queryParams?: GetEpayRequestQueryParams,options?:SwaggerTypescriptUseQueryOptions<EpayRequestApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequest.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestAudiencesRecent = (
+           options?:SwaggerTypescriptUseQueryOptions<ContactApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestAudiencesRecent.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestAudiencesRecent.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestAudiencesRecent.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestAudiencesRecent(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestAudiencesRecent.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<ContactApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestAudiencesRecent.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestCount = (
+           queryParams?: GetEpayRequestCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestCount.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestCount.info = (queryParams?: GetEpayRequestCountQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestCount.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestCount(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestCount.prefetch = (
+            client: QueryClient,
+            queryParams?: GetEpayRequestCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestCount.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get epay request detail based on Id
+ */
+export const useGetEpayRequestEpayId = (
+           
+/**
+ * 
+ * EpayRequest's Id
+ */
+epayId: number,options?:SwaggerTypescriptUseQueryOptions< & (EpayRequestDetailApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestEpayId.info( epayId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestEpayId.info = (
+/**
+ * 
+ * EpayRequest's Id
+ */
+epayId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestEpayId.key,epayId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestEpayId(
+                   epayId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestEpayId.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * EpayRequest's Id
+ */
+epayId: number,options?:SwaggerTypescriptUseQueryOptions< & (EpayRequestDetailApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestEpayId.info( epayId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestEpayTokenDetail = (
+           epayToken: string,options?:SwaggerTypescriptUseQueryOptions< & (EpayRequestPublicInfoApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestEpayTokenDetail.info( epayToken,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestEpayTokenDetail.info = (epayToken: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestEpayTokenDetail.key,epayToken,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestEpayTokenDetail(
+                   epayToken,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestEpayTokenDetail.prefetch = (
+            client: QueryClient,
+            epayToken: string,options?:SwaggerTypescriptUseQueryOptions< & (EpayRequestPublicInfoApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestEpayTokenDetail.info( epayToken,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get QR code image file for epay request
+ */
+export const useGetEpayRequestEpayTokenQrcode = (
+           
+/**
+ * 
+ * epay request token
+ */
+epayToken: string,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestEpayTokenQrcode.info( epayToken,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestEpayTokenQrcode.info = (
+/**
+ * 
+ * epay request token
+ */
+epayToken: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestEpayTokenQrcode.key,epayToken,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestEpayTokenQrcode(
+                   epayToken,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestEpayTokenQrcode.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * epay request token
+ */
+epayToken: string,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestEpayTokenQrcode.info( epayToken,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestExcel = (
+           queryParams?: GetEpayRequestExcelQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestExcel.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestExcel.info = (queryParams?: GetEpayRequestExcelQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestExcel.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestExcel(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestExcel.prefetch = (
+            client: QueryClient,
+            queryParams?: GetEpayRequestExcelQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestExcel.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get pay requests that the user is one of its audiences.
+[Feature is not allowed for sub users]
+[Needs secure login]
+ */
+export const useGetEpayRequestForMe = (
+           queryParams?: GetEpayRequestForMeQueryParams,options?:SwaggerTypescriptUseQueryOptions<EpayRequestForUserQuery[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestForMe.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestForMe.info = (queryParams?: GetEpayRequestForMeQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestForMe.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestForMe(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestForMe.prefetch = (
+            client: QueryClient,
+            queryParams?: GetEpayRequestForMeQueryParams,options?:SwaggerTypescriptUseQueryOptions<EpayRequestForUserQuery[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestForMe.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestForMeCount = (
+           queryParams?: GetEpayRequestForMeCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestForMeCount.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestForMeCount.info = (queryParams?: GetEpayRequestForMeCountQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestForMeCount.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestForMeCount(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestForMeCount.prefetch = (
+            client: QueryClient,
+            queryParams?: GetEpayRequestForMeCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestForMeCount.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestForMeReport = (
+           queryParams?: GetEpayRequestForMeReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReportApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestForMeReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestForMeReport.info = (queryParams?: GetEpayRequestForMeReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestForMeReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestForMeReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestForMeReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetEpayRequestForMeReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReportApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestForMeReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * [Deprecated, use 'account/{accountNumber}/qrcode' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetEpayRequestPosQrAccountNumber = (
+           accountNumber: string,queryParams?: GetEpayRequestPosQrAccountNumberQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestPosQrAccountNumber.info( accountNumber,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestPosQrAccountNumber.info = (accountNumber: string,queryParams?: GetEpayRequestPosQrAccountNumberQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestPosQrAccountNumber.key,accountNumber,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestPosQrAccountNumber(
+                   accountNumber,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestPosQrAccountNumber.prefetch = (
+            client: QueryClient,
+            accountNumber: string,queryParams?: GetEpayRequestPosQrAccountNumberQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestPosQrAccountNumber.info( accountNumber,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestReport = (
+           queryParams?: GetEpayRequestReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReportApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestReport.info = (queryParams?: GetEpayRequestReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetEpayRequestReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReportApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get comission amount for epay request amount
+ */
+export const useGetEpayRequestUserWalletIdCommission = (
+           userWalletId: number,queryParams?: GetEpayRequestUserWalletIdCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestUserWalletIdCommission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestUserWalletIdCommission.info = (userWalletId: number,queryParams?: GetEpayRequestUserWalletIdCommissionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestUserWalletIdCommission.key,userWalletId,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestUserWalletIdCommission(
+                   userWalletId,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestUserWalletIdCommission.prefetch = (
+            client: QueryClient,
+            userWalletId: number,queryParams?: GetEpayRequestUserWalletIdCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestUserWalletIdCommission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetEpayRequestUserWalletIdCreators = (
+           userWalletId: number,options?:SwaggerTypescriptUseQueryOptions<UserMinimalDto[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestUserWalletIdCreators.info( userWalletId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestUserWalletIdCreators.info = (userWalletId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestUserWalletIdCreators.key,userWalletId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestUserWalletIdCreators(
+                   userWalletId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestUserWalletIdCreators.prefetch = (
+            client: QueryClient,
+            userWalletId: number,options?:SwaggerTypescriptUseQueryOptions<UserMinimalDto[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestUserWalletIdCreators.info( userWalletId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetError = (
+           options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetError.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetError.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getError.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getError(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetError.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetError.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetErrorLocal = (
+           options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetErrorLocal.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetErrorLocal.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getErrorLocal.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getErrorLocal(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetErrorLocal.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetErrorLocal.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetErrorStatusCode = (
+           code: number,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetErrorStatusCode.info( code,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetErrorStatusCode.info = (code: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getErrorStatusCode.key,code,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getErrorStatusCode(
+                   code,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetErrorStatusCode.prefetch = (
+            client: QueryClient,
+            code: number,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetErrorStatusCode.info( code,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Download a file.
+ */
+export const useGetFileFileGuid = (
+           
+/**
+ * 
+ * file unique id
+ */
+fileGuid: string,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetFileFileGuid.info( fileGuid,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetFileFileGuid.info = (
+/**
+ * 
+ * file unique id
+ */
+fileGuid: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getFileFileGuid.key,fileGuid,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getFileFileGuid(
+                   fileGuid,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetFileFileGuid.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * file unique id
+ */
+fileGuid: string,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetFileFileGuid.info( fileGuid,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetGroupTransferCommission = (
+           queryParams?: GetGroupTransferCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetGroupTransferCommission.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetGroupTransferCommission.info = (queryParams?: GetGroupTransferCommissionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getGroupTransferCommission.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getGroupTransferCommission(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetGroupTransferCommission.prefetch = (
+            client: QueryClient,
+            queryParams?: GetGroupTransferCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetGroupTransferCommission.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get detailed driver,taxi and fair amount information
+ */
+export const useGetIntegration = (
+           queryParams?: GetIntegrationQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (DriverInfoResult)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetIntegration.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetIntegration.info = (queryParams?: GetIntegrationQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getIntegration.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getIntegration(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetIntegration.prefetch = (
+            client: QueryClient,
+            queryParams?: GetIntegrationQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (DriverInfoResult)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetIntegration.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetKpi = (
+           queryParams?: GetKpiQueryParams,options?:SwaggerTypescriptUseQueryOptions<KpiResult[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetKpi.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetKpi.info = (queryParams?: GetKpiQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getKpi.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getKpi(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetKpi.prefetch = (
+            client: QueryClient,
+            queryParams?: GetKpiQueryParams,options?:SwaggerTypescriptUseQueryOptions<KpiResult[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetKpi.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetKpiCurrent = (
+           queryParams?: GetKpiCurrentQueryParams,options?:SwaggerTypescriptUseQueryOptions<KpiResult[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetKpiCurrent.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetKpiCurrent.info = (queryParams?: GetKpiCurrentQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getKpiCurrent.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getKpiCurrent(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetKpiCurrent.prefetch = (
+            client: QueryClient,
+            queryParams?: GetKpiCurrentQueryParams,options?:SwaggerTypescriptUseQueryOptions<KpiResult[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetKpiCurrent.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetKpiLast = (
+           queryParams?: GetKpiLastQueryParams,options?:SwaggerTypescriptUseQueryOptions<KpiResult[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetKpiLast.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetKpiLast.info = (queryParams?: GetKpiLastQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getKpiLast.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getKpiLast(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetKpiLast.prefetch = (
+            client: QueryClient,
+            queryParams?: GetKpiLastQueryParams,options?:SwaggerTypescriptUseQueryOptions<KpiResult[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetKpiLast.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get all Important Actions of current user.
+ */
+export const useGetNotificationIa = (
+           options?:SwaggerTypescriptUseQueryOptions<ImportantActionApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetNotificationIa.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetNotificationIa.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getNotificationIa.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getNotificationIa(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetNotificationIa.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<ImportantActionApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetNotificationIa.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get Notifications of current user.
+Maximum 99 items will be returned.
+ */
+export const useGetNotificationNotif = (
+           options?:SwaggerTypescriptUseQueryOptions<NotificationApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetNotificationNotif.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetNotificationNotif.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getNotificationNotif.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getNotificationNotif(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetNotificationNotif.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<NotificationApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetNotificationNotif.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetNotificationUnread = (
+           queryParams?: GetNotificationUnreadQueryParams,options?:SwaggerTypescriptUseQueryOptions<UnreadNotificationCountApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetNotificationUnread.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetNotificationUnread.info = (queryParams?: GetNotificationUnreadQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getNotificationUnread.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getNotificationUnread(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetNotificationUnread.prefetch = (
+            client: QueryClient,
+            queryParams?: GetNotificationUnreadQueryParams,options?:SwaggerTypescriptUseQueryOptions<UnreadNotificationCountApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetNotificationUnread.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetPluginPluginId = (
+           pluginId: number,options?:SwaggerTypescriptUseQueryOptions< & (PluginApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetPluginPluginId.info( pluginId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetPluginPluginId.info = (pluginId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getPluginPluginId.key,pluginId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getPluginPluginId(
+                   pluginId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetPluginPluginId.prefetch = (
+            client: QueryClient,
+            pluginId: number,options?:SwaggerTypescriptUseQueryOptions< & (PluginApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetPluginPluginId.info( pluginId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get epay request detail
+ */
+export const useGetPosAccountNumber = (
+           
+/**
+ * 
+ * Account Number
+ */
+accountNumber: string,queryParams?: GetPosAccountNumberQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (PosLandingPageApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetPosAccountNumber.info( accountNumber,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetPosAccountNumber.info = (
+/**
+ * 
+ * Account Number
+ */
+accountNumber: string,queryParams?: GetPosAccountNumberQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getPosAccountNumber.key,accountNumber,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getPosAccountNumber(
+                   accountNumber,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetPosAccountNumber.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * Account Number
+ */
+accountNumber: string,queryParams?: GetPosAccountNumberQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (PosLandingPageApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetPosAccountNumber.info( accountNumber,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get bank receipt by EPayTry id
+[For anonymous users]
+ */
+export const useGetReceiptBankEpayTryId = (
+           
+/**
+ * 
+ * EpayTry's id to get receipt for
+ */
+epayTryId: string,options?:SwaggerTypescriptUseQueryOptions< & (BankReceiptApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetReceiptBankEpayTryId.info( epayTryId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetReceiptBankEpayTryId.info = (
+/**
+ * 
+ * EpayTry's id to get receipt for
+ */
+epayTryId: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getReceiptBankEpayTryId.key,epayTryId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getReceiptBankEpayTryId(
+                   epayTryId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetReceiptBankEpayTryId.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * EpayTry's id to get receipt for
+ */
+epayTryId: string,options?:SwaggerTypescriptUseQueryOptions< & (BankReceiptApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetReceiptBankEpayTryId.info( epayTryId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get bank receipt by EPayRequest token
+[For anonymous users]
+[Deprecated, use 'receipt/bank/{epayTryId}' and 'receipt/bank/{epayTryId}' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetReceiptEpayToken = (
+           
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,options?:SwaggerTypescriptUseQueryOptions< & (BankReceiptApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetReceiptEpayToken.info( epayToken,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetReceiptEpayToken.info = (
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getReceiptEpayToken.key,epayToken,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getReceiptEpayToken(
+                   epayToken,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetReceiptEpayToken.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,options?:SwaggerTypescriptUseQueryOptions< & (BankReceiptApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetReceiptEpayToken.info( epayToken,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get wallet receipt by EPayRequest token
+[For anonymous users]
+ */
+export const useGetReceiptWalletEpayToken = (
+           
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,options?:SwaggerTypescriptUseQueryOptions< & (WalletReceiptApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetReceiptWalletEpayToken.info( epayToken,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetReceiptWalletEpayToken.info = (
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getReceiptWalletEpayToken.key,epayToken,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getReceiptWalletEpayToken(
+                   epayToken,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetReceiptWalletEpayToken.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * EpayRequest's token to get receipt for
+ */
+epayToken: string,options?:SwaggerTypescriptUseQueryOptions< & (WalletReceiptApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetReceiptWalletEpayToken.info( epayToken,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the Resellership info of current Reseller user
+[Feature just allowed for Resellers]
+ */
+export const useGetResellerUser = (
+           options?:SwaggerTypescriptUseQueryOptions< & (ResellerApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUser.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUser.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUser.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getResellerUser(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUser.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions< & (ResellerApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUser.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the time-based report of commissions paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardCommissionReport = (
+           queryParams?: GetResellerUserDashboardCommissionReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfDecimal[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardCommissionReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardCommissionReport.info = (queryParams?: GetResellerUserDashboardCommissionReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardCommissionReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardCommissionReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardCommissionReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardCommissionReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfDecimal[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardCommissionReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get sum of all commissions paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardCommissionSum = (
+           queryParams?: GetResellerUserDashboardCommissionSumQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardCommissionSum.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardCommissionSum.info = (queryParams?: GetResellerUserDashboardCommissionSumQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardCommissionSum.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardCommissionSum(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardCommissionSum.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardCommissionSumQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardCommissionSum.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get count of all users reselled by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardIntroducedCount = (
+           queryParams?: GetResellerUserDashboardIntroducedCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardIntroducedCount.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardIntroducedCount.info = (queryParams?: GetResellerUserDashboardIntroducedCountQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardIntroducedCount.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardIntroducedCount(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardIntroducedCount.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardIntroducedCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardIntroducedCount.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get time-based report of users reselled by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardIntroducedReport = (
+           queryParams?: GetResellerUserDashboardIntroducedReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardIntroducedReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardIntroducedReport.info = (queryParams?: GetResellerUserDashboardIntroducedReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardIntroducedReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardIntroducedReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardIntroducedReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardIntroducedReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardIntroducedReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get count of all links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardLinksCount = (
+           queryParams?: GetResellerUserDashboardLinksCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardLinksCount.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardLinksCount.info = (queryParams?: GetResellerUserDashboardLinksCountQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardLinksCount.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardLinksCount(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardLinksCount.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardLinksCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardLinksCount.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get count of all paid links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardLinksPaidCount = (
+           queryParams?: GetResellerUserDashboardLinksPaidCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardLinksPaidCount.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardLinksPaidCount.info = (queryParams?: GetResellerUserDashboardLinksPaidCountQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardLinksPaidCount.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardLinksPaidCount(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardLinksPaidCount.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardLinksPaidCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardLinksPaidCount.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get time-based report of paid links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardLinksPaidReport = (
+           queryParams?: GetResellerUserDashboardLinksPaidReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardLinksPaidReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardLinksPaidReport.info = (queryParams?: GetResellerUserDashboardLinksPaidReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardLinksPaidReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardLinksPaidReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardLinksPaidReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardLinksPaidReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardLinksPaidReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get time-based report of links generated by users, who are introduced by current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardLinksReport = (
+           queryParams?: GetResellerUserDashboardLinksReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardLinksReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardLinksReport.info = (queryParams?: GetResellerUserDashboardLinksReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardLinksReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardLinksReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardLinksReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardLinksReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardLinksReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get count of all commission transactions, paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardTransactionsCount = (
+           queryParams?: GetResellerUserDashboardTransactionsCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardTransactionsCount.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardTransactionsCount.info = (queryParams?: GetResellerUserDashboardTransactionsCountQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardTransactionsCount.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardTransactionsCount(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardTransactionsCount.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardTransactionsCountQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AggregationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardTransactionsCount.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get time-based report of commission transactions, paid to current Reseller user
+[Feature just allowed for Resellers]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetResellerUserDashboardTransactionsReport = (
+           queryParams?: GetResellerUserDashboardTransactionsReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserDashboardTransactionsReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserDashboardTransactionsReport.info = (queryParams?: GetResellerUserDashboardTransactionsReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserDashboardTransactionsReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserDashboardTransactionsReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserDashboardTransactionsReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserDashboardTransactionsReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<DateReportApiModelOfInteger[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserDashboardTransactionsReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the Users Introduced by current Reseller user
+[Feature just allowed for Resellers]
+ */
+export const useGetResellerUserIntroduced = (
+           queryParams?: GetResellerUserIntroducedQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReselledUserApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserIntroduced.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserIntroduced.info = (queryParams?: GetResellerUserIntroducedQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserIntroduced.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserIntroduced(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserIntroduced.prefetch = (
+            client: QueryClient,
+            queryParams?: GetResellerUserIntroducedQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReselledUserApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserIntroduced.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get filter data items to populate DropDowns
+[Feature just allowed for Resellers]
+ */
+export const useGetResellerUserIntroducedFilterData = (
+           options?:SwaggerTypescriptUseQueryOptions< & (ReselledUserFilterData)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserIntroducedFilterData.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserIntroducedFilterData.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserIntroducedFilterData.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserIntroducedFilterData(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserIntroducedFilterData.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions< & (ReselledUserFilterData)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserIntroducedFilterData.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the User activity
+[Feature just allowed for Resellers]
+ */
+export const useGetResellerUserIntroducedUserIdActivity = (
+           userId: string,options?:SwaggerTypescriptUseQueryOptions< & (ReselledUserActivityApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetResellerUserIntroducedUserIdActivity.info( userId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetResellerUserIntroducedUserIdActivity.info = (userId: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getResellerUserIntroducedUserIdActivity.key,userId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getResellerUserIntroducedUserIdActivity(
+                   userId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetResellerUserIntroducedUserIdActivity.prefetch = (
+            client: QueryClient,
+            userId: string,options?:SwaggerTypescriptUseQueryOptions< & (ReselledUserActivityApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetResellerUserIntroducedUserIdActivity.info( userId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the SubDomain of current Reseller user
+[Feature just allowed for Resellers]
+ */
+export const useGetSubDomain = (
+           options?:SwaggerTypescriptUseQueryOptions< & (SubDomainApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetSubDomain.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetSubDomain.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getSubDomain.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getSubDomain(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetSubDomain.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions< & (SubDomainApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetSubDomain.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get info of a SubDomain by it's address.
+ */
+export const useGetSubDomainSubDomainAddress = (
+           
+/**
+ * 
+ * The SubDomain part of the url.
+            
+ */
+subDomainAddress: string,headerParams?: {
+/**
+ * 
+ * - Format: guid
+ */
+\\"clientId\\": string;},options?:SwaggerTypescriptUseQueryOptions< & (SubDomainApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetSubDomainSubDomainAddress.info( subDomainAddress,
+          
+          
+          headerParams, configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetSubDomainSubDomainAddress.info = (
+/**
+ * 
+ * The SubDomain part of the url.
+            
+ */
+subDomainAddress: string,headerParams?: {
+/**
+ * 
+ * - Format: guid
+ */
+\\"clientId\\": string;},configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getSubDomainSubDomainAddress.key,subDomainAddress,
+            
+            
+            headerParams,] as QueryKey,
+                fun: () =>
+                getSubDomainSubDomainAddress(
+                   subDomainAddress,
+          
+          
+          headerParams,
+                  configOverride
+                ),
+              };
+            };useGetSubDomainSubDomainAddress.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * The SubDomain part of the url.
+            
+ */
+subDomainAddress: string,headerParams?: {
+/**
+ * 
+ * - Format: guid
+ */
+\\"clientId\\": string;},options?:SwaggerTypescriptUseQueryOptions< & (SubDomainApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetSubDomainSubDomainAddress.info( subDomainAddress,
+          
+          
+          headerParams, configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get permission details of an Account
+[Feature just allowed for SubUsers]
+ */
+export const useGetSubUserAccountUserWalletId = (
+           userWalletId: number,options?:SwaggerTypescriptUseQueryOptions< & (SubUserAccountDetailQuery)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetSubUserAccountUserWalletId.info( userWalletId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetSubUserAccountUserWalletId.info = (userWalletId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getSubUserAccountUserWalletId.key,userWalletId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getSubUserAccountUserWalletId(
+                   userWalletId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetSubUserAccountUserWalletId.prefetch = (
+            client: QueryClient,
+            userWalletId: number,options?:SwaggerTypescriptUseQueryOptions< & (SubUserAccountDetailQuery)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetSubUserAccountUserWalletId.info( userWalletId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the connections
+[Feature just allowed for SubUsers]
+[Deprecated. use 'user/connection' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetSubUserConnection = (
+           options?:SwaggerTypescriptUseQueryOptions<BusinessUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetSubUserConnection.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetSubUserConnection.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getSubUserConnection.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getSubUserConnection(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetSubUserConnection.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<BusinessUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetSubUserConnection.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetTransaction = (
+           queryParams?: GetTransactionQueryParams,options?:SwaggerTypescriptUseQueryOptions<TransactionApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransaction.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransaction.info = (queryParams?: GetTransactionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransaction.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getTransaction(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetTransaction.prefetch = (
+            client: QueryClient,
+            queryParams?: GetTransactionQueryParams,options?:SwaggerTypescriptUseQueryOptions<TransactionApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransaction.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetTransactionExcel = (
+           queryParams?: GetTransactionExcelQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransactionExcel.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransactionExcel.info = (queryParams?: GetTransactionExcelQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransactionExcel.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getTransactionExcel(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetTransactionExcel.prefetch = (
+            client: QueryClient,
+            queryParams?: GetTransactionExcelQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransactionExcel.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetTransactionReport = (
+           queryParams?: GetTransactionReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReportApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransactionReport.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransactionReport.info = (queryParams?: GetTransactionReportQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransactionReport.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getTransactionReport(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetTransactionReport.prefetch = (
+            client: QueryClient,
+            queryParams?: GetTransactionReportQueryParams,options?:SwaggerTypescriptUseQueryOptions<ReportApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransactionReport.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetTransactionReportAll = (
+           queryParams?: GetTransactionReportAllQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AllTransactionsReportApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransactionReportAll.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransactionReportAll.info = (queryParams?: GetTransactionReportAllQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransactionReportAll.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getTransactionReportAll(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetTransactionReportAll.prefetch = (
+            client: QueryClient,
+            queryParams?: GetTransactionReportAllQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AllTransactionsReportApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransactionReportAll.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get a Transaction by it's Id
+[Needs secure login]
+ */
+export const useGetTransactionTransactionId = (
+           transactionId: number,options?:SwaggerTypescriptUseQueryOptions< & (TransactionApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransactionTransactionId.info( transactionId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransactionTransactionId.info = (transactionId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransactionTransactionId.key,transactionId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getTransactionTransactionId(
+                   transactionId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetTransactionTransactionId.prefetch = (
+            client: QueryClient,
+            transactionId: number,options?:SwaggerTypescriptUseQueryOptions< & (TransactionApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransactionTransactionId.info( transactionId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get recent money transfers
+ */
+export const useGetTransferRecent = (
+           queryParams?: GetTransferRecentQueryParams,options?:SwaggerTypescriptUseQueryOptions<TransferMoneyApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransferRecent.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransferRecent.info = (queryParams?: GetTransferRecentQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransferRecent.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getTransferRecent(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetTransferRecent.prefetch = (
+            client: QueryClient,
+            queryParams?: GetTransferRecentQueryParams,options?:SwaggerTypescriptUseQueryOptions<TransferMoneyApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransferRecent.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetTransferSearch = (
+           queryParams?: GetTransferSearchQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AccountInfoApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransferSearch.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransferSearch.info = (queryParams?: GetTransferSearchQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransferSearch.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getTransferSearch(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetTransferSearch.prefetch = (
+            client: QueryClient,
+            queryParams?: GetTransferSearchQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AccountInfoApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransferSearch.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get commission amount for transfer money amount
+ */
+export const useGetTransferUserWalletIdCommission = (
+           userWalletId: number,queryParams?: GetTransferUserWalletIdCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransferUserWalletIdCommission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransferUserWalletIdCommission.info = (userWalletId: number,queryParams?: GetTransferUserWalletIdCommissionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransferUserWalletIdCommission.key,userWalletId,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getTransferUserWalletIdCommission(
+                   userWalletId,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetTransferUserWalletIdCommission.prefetch = (
+            client: QueryClient,
+            userWalletId: number,queryParams?: GetTransferUserWalletIdCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransferUserWalletIdCommission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get [normal/sub/business] user profile detail
+ */
+export const useGetUser = (
+           options?:SwaggerTypescriptUseQueryOptions< & (UserDetailQuery)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUser.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUser.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUser.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUser(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUser.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions< & (UserDetailQuery)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUser.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get user banks
+[Feature is not allowed for sub users.]
+ */
+export const useGetUserBank = (
+           options?:SwaggerTypescriptUseQueryOptions<UserBankApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserBank.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserBank.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserBank.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserBank(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserBank.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<UserBankApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserBank.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get available user banks
+[Feature is not allowed for sub users.]
+ */
+export const useGetUserBankReady = (
+           options?:SwaggerTypescriptUseQueryOptions<UserBankApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserBankReady.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserBankReady.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserBankReady.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserBankReady(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserBankReady.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<UserBankApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserBankReady.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * get user bank detail
+[Needs secure login]
+ */
+export const useGetUserBankUserBankId = (
+           
+/**
+ * 
+ * User bank id
+ */
+userBankId: number,options?:SwaggerTypescriptUseQueryOptions< & (UserBankDetailApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserBankUserBankId.info( userBankId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserBankUserBankId.info = (
+/**
+ * 
+ * User bank id
+ */
+userBankId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserBankUserBankId.key,userBankId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserBankUserBankId(
+                   userBankId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserBankUserBankId.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * User bank id
+ */
+userBankId: number,options?:SwaggerTypescriptUseQueryOptions< & (UserBankDetailApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserBankUserBankId.info( userBankId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get the connections [Feature is allowed for normal users noly]
+ */
+export const useGetUserConnection = (
+           options?:SwaggerTypescriptUseQueryOptions<BusinessUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserConnection.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserConnection.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserConnection.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserConnection(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserConnection.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<BusinessUserConnectionApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserConnection.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetUserContactInput = (
+           input: string,options?:SwaggerTypescriptUseQueryOptions< & (ContactApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserContactInput.info( input,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserContactInput.info = (input: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserContactInput.key,input,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserContactInput(
+                   input,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserContactInput.prefetch = (
+            client: QueryClient,
+            input: string,options?:SwaggerTypescriptUseQueryOptions< & (ContactApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserContactInput.info( input,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get last national id verification request [Feature is not allowed for sub users]
+ */
+export const useGetUserIdentityRequest = (
+           options?:SwaggerTypescriptUseQueryOptions< & (UserIdentityRequestQuery)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserIdentityRequest.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserIdentityRequest.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserIdentityRequest.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserIdentityRequest(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserIdentityRequest.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions< & (UserIdentityRequestQuery)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserIdentityRequest.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get business user invitations for me [Feature is not allowed for sub users]
+ */
+export const useGetUserInvitation = (
+           options?:SwaggerTypescriptUseQueryOptions<SubUserInvitationApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserInvitation.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserInvitation.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserInvitation.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserInvitation(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserInvitation.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<SubUserInvitationApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserInvitation.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get business user invitations for me [Feature is not allowed for sub users]
+ */
+export const useGetUserInvitationInvitationToken = (
+           invitationToken: string,options?:SwaggerTypescriptUseQueryOptions< & (SubUserInvitationApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserInvitationInvitationToken.info( invitationToken,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserInvitationInvitationToken.info = (invitationToken: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserInvitationInvitationToken.key,invitationToken,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserInvitationInvitationToken(
+                   invitationToken,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserInvitationInvitationToken.prefetch = (
+            client: QueryClient,
+            invitationToken: string,options?:SwaggerTypescriptUseQueryOptions< & (SubUserInvitationApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserInvitationInvitationToken.info( invitationToken,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get user profile summary
+ */
+export const useGetUserMe = (
+           options?:SwaggerTypescriptUseQueryOptions< & (UserMeQuery)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserMe.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserMe.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserMe.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserMe(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserMe.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions< & (UserMeQuery)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserMe.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetUserPlugin = (
+           options?:SwaggerTypescriptUseQueryOptions<UserPluginDetailApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserPlugin.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserPlugin.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserPlugin.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserPlugin(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserPlugin.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<UserPluginDetailApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserPlugin.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get Last Request for upgrade account to the business [Feature is allowed for normal users only]
+ */
+export const useGetUserUpgradeToBusinessRequest = (
+           options?:SwaggerTypescriptUseQueryOptions< & (UpgradeToBusinessApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserUpgradeToBusinessRequest.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserUpgradeToBusinessRequest.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserUpgradeToBusinessRequest.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserUpgradeToBusinessRequest(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserUpgradeToBusinessRequest.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions< & (UpgradeToBusinessApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserUpgradeToBusinessRequest.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetUserWallet = (
+           options?:SwaggerTypescriptUseQueryOptions<WalletDisplayApiModel[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWallet.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWallet.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWallet.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserWallet(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWallet.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<WalletDisplayApiModel[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWallet.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetUserWalletAccountNumberQrcode = (
+           accountNumber: string,queryParams?: GetUserWalletAccountNumberQrcodeQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletAccountNumberQrcode.info( accountNumber,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletAccountNumberQrcode.info = (accountNumber: string,queryParams?: GetUserWalletAccountNumberQrcodeQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletAccountNumberQrcode.key,accountNumber,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletAccountNumberQrcode(
+                   accountNumber,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletAccountNumberQrcode.prefetch = (
+            client: QueryClient,
+            accountNumber: string,queryParams?: GetUserWalletAccountNumberQrcodeQueryParams,options?:SwaggerTypescriptUseQueryOptions<string>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletAccountNumberQrcode.info( accountNumber,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetUserWalletSearch = (
+           queryParams?: GetUserWalletSearchQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AccountInfoApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletSearch.info( 
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletSearch.info = (queryParams?: GetUserWalletSearchQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletSearch.key,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletSearch(
+                   
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletSearch.prefetch = (
+            client: QueryClient,
+            queryParams?: GetUserWalletSearchQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (AccountInfoApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletSearch.info( 
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetUserWalletUserWalletId = (
+           userWalletId: number,options?:SwaggerTypescriptUseQueryOptions< & (WalletDetailApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletUserWalletId.info( userWalletId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletUserWalletId.info = (userWalletId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletUserWalletId.key,userWalletId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletUserWalletId(
+                   userWalletId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletUserWalletId.prefetch = (
+            client: QueryClient,
+            userWalletId: number,options?:SwaggerTypescriptUseQueryOptions< & (WalletDetailApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletUserWalletId.info( userWalletId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get user account balance
+ */
+export const useGetUserWalletUserWalletIdBalance = (
+           userWalletId: number,options?:SwaggerTypescriptUseQueryOptions< & (AccountBalanceApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletUserWalletIdBalance.info( userWalletId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletUserWalletIdBalance.info = (userWalletId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletUserWalletIdBalance.key,userWalletId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletUserWalletIdBalance(
+                   userWalletId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletUserWalletIdBalance.prefetch = (
+            client: QueryClient,
+            userWalletId: number,options?:SwaggerTypescriptUseQueryOptions< & (AccountBalanceApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletUserWalletIdBalance.info( userWalletId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetUserWalletUserWalletIdEpayRequestComission = (
+           userWalletId: number,queryParams?: GetUserWalletUserWalletIdEpayRequestComissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletUserWalletIdEpayRequestComission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletUserWalletIdEpayRequestComission.info = (userWalletId: number,queryParams?: GetUserWalletUserWalletIdEpayRequestComissionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletUserWalletIdEpayRequestComission.key,userWalletId,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletUserWalletIdEpayRequestComission(
+                   userWalletId,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletUserWalletIdEpayRequestComission.prefetch = (
+            client: QueryClient,
+            userWalletId: number,queryParams?: GetUserWalletUserWalletIdEpayRequestComissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletUserWalletIdEpayRequestComission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetUserWalletUserWalletIdPermittedsubusers = (
+           userWalletId: number,options?:SwaggerTypescriptUseQueryOptions<AccountPermittedSubUserQuery[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletUserWalletIdPermittedsubusers.info( userWalletId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletUserWalletIdPermittedsubusers.info = (userWalletId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletUserWalletIdPermittedsubusers.key,userWalletId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletUserWalletIdPermittedsubusers(
+                   userWalletId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletUserWalletIdPermittedsubusers.prefetch = (
+            client: QueryClient,
+            userWalletId: number,options?:SwaggerTypescriptUseQueryOptions<AccountPermittedSubUserQuery[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletUserWalletIdPermittedsubusers.info( userWalletId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetUserWalletUserWalletIdSettlementRequestComission = (
+           userWalletId: number,queryParams?: GetUserWalletUserWalletIdSettlementRequestComissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletUserWalletIdSettlementRequestComission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletUserWalletIdSettlementRequestComission.info = (userWalletId: number,queryParams?: GetUserWalletUserWalletIdSettlementRequestComissionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletUserWalletIdSettlementRequestComission.key,userWalletId,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletUserWalletIdSettlementRequestComission(
+                   userWalletId,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletUserWalletIdSettlementRequestComission.prefetch = (
+            client: QueryClient,
+            userWalletId: number,queryParams?: GetUserWalletUserWalletIdSettlementRequestComissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletUserWalletIdSettlementRequestComission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useGetUserWalletUserWalletIdTransferMoneyCommission = (
+           userWalletId: number,queryParams?: GetUserWalletUserWalletIdTransferMoneyCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletUserWalletIdTransferMoneyCommission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletUserWalletIdTransferMoneyCommission.info = (userWalletId: number,queryParams?: GetUserWalletUserWalletIdTransferMoneyCommissionQueryParams,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletUserWalletIdTransferMoneyCommission.key,userWalletId,
+            
+            queryParams,
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletUserWalletIdTransferMoneyCommission(
+                   userWalletId,
+          
+          queryParams,
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletUserWalletIdTransferMoneyCommission.prefetch = (
+            client: QueryClient,
+            userWalletId: number,queryParams?: GetUserWalletUserWalletIdTransferMoneyCommissionQueryParams,options?:SwaggerTypescriptUseQueryOptions< & (CommissionAmountApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletUserWalletIdTransferMoneyCommission.info( userWalletId,
+          
+          queryParams,
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get user work spaces
+ */
+export const useGetUserWorkspace = (
+           options?:SwaggerTypescriptUseQueryOptions<UserWorkspaceQuery[]>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWorkspace.info( 
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWorkspace.info = (configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWorkspace.key,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserWorkspace(
+                   
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWorkspace.prefetch = (
+            client: QueryClient,
+            options?:SwaggerTypescriptUseQueryOptions<UserWorkspaceQuery[]>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWorkspace.info( 
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }"
+`;
+
+exports[`only includes get methods generate type 1`] = `
+"
+//@ts-nocheck
+/**
+* AUTO_GENERATED Do not change this file directly, use config.ts file instead
+*
+* @version 6
+*/
+
+        
+        export interface AccountBalanceApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"realBalance\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"totalBalance\\": number;}
+        
+        
+        export interface AccountCreationApiModel {\\"automaticSettlement\\"?: boolean;\\"getComissionFromPayer\\"?: boolean;\\"isActive\\"?: boolean;\\"title\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"userBankId\\"?: number;}
+        
+        
+        export interface AccountInfoApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"accountOwnerAvatarUrl\\"?: string;\\"accountOwnerTitle\\"?: string;}
+        
+        
+        export interface AccountPermittedSubUserQuery {
+/**
+ * 
+ * - Format: int64
+ */
+\\"connectionId\\": number;\\"connectionStatus\\": SubUserConnectionStatus;
+/**
+ * 
+ * [Deprecated, use 'ConnectionStatus' instead]
+ * @deprecated Use 'ConnectionStatus' instead.
+ */
+\\"subUserConnectionStatus\\":  & (SubUserConnectionStatus);
+/**
+ * 
+ * - Format: guid
+ */
+\\"subuserId\\": string;\\"subuserStatus\\": SubuserStatus;\\"connectDate\\"?: string;\\"connectionStatusDisplay\\"?: string;\\"disconnectDate\\"?: string;\\"subUserAvatarUrl\\"?: string;\\"subUserContact\\"?: string;\\"subUserPositionTitle\\"?: string;\\"subUserTitle\\"?: string;\\"subuserStatusDisplay\\"?: string;}
+        
+        
+        export interface AccountSettingNotificationStatusApiModel {\\"notificationEnabled\\": boolean;}
+        
+        
+        export enum AccountStatus {Block=\\"Block\\",OK=\\"OK\\"}
+        
+        
+        export interface AggregationApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"count\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"sum\\": number;}
+        
+        
+        export interface AllTransactionsReportApiModel {\\"credits\\"?: ReportApiModel[];\\"debits\\"?: ReportApiModel[];}
+        
+        
+        export interface BankApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"id\\": number;\\"logoUrl\\"?: string;\\"name\\"?: string;}
+        
+        
+        export interface BankReceiptApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionAmount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDate\\": string;\\"failed\\": boolean;\\"type\\": EpayRequestType;\\"createDateDisplay\\"?: string;\\"creatorUserAvatarUrl\\"?: string;\\"creatorUserDisplayName\\"?: string;\\"description\\"?: string;\\"failureMessage\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"operationId\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"payerAccountId\\"?: number;\\"payerAccountName\\"?: string;\\"payerAccountNumber\\"?: string;\\"shareUrl\\"?: string;\\"targetAccountNumber\\"?: string;\\"targetAvatarUrl\\"?: string;\\"targetUserDisplayName\\"?: string;\\"typeDisplay\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"voucherId\\"?: number;}
+        
+        
+        export interface BusinessCategoryApiModel {\\"id\\": BusinessType;\\"title\\"?: string;}
+        
+        
+        export enum BusinessShareType {Person=\\"Person\\",PrivateStock=\\"PrivateStock\\",PublicStock=\\"PublicStock\\",Limited=\\"Limited\\",GeneralPartnership=\\"GeneralPartnership\\",Institute=\\"Institute\\",Cooperative=\\"Cooperative\\"}
+        
+        
+        export enum BusinessType {Ads=\\"Ads\\",Investment=\\"Investment\\",Production=\\"Production\\",Trade=\\"Trade\\",Software=\\"Software\\"}
+        
+        
+        export interface BusinessUserConnectionApiModel {
+/**
+ * 
+ * - Format: guid
+ */
+\\"businessId\\": string;\\"status\\": SubUserConnectionStatus;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"subUserConnectionStatus\\":  & (SubUserConnectionStatus);\\"businessAvatarUrl\\"?: string;\\"businessName\\"?: string;\\"connectDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"connectDateTime\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"connectionId\\"?: number;\\"disconnectDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"disconnectDateTime\\"?: string;\\"positionTitle\\"?: string;\\"statusDisplay\\"?: string;}
+        
+        
+        export enum CallbackType {None=\\"None\\",Redirect=\\"Redirect\\",RedirectWithPost=\\"RedirectWithPost\\",Call=\\"Call\\"}
+        
+        
+        export interface ClientPurchaseInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"instituteCode\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"userWalletId\\": number;\\"driverCode\\"?: string;}
+        
+        
+        export enum ComissionType {Percentage=\\"Percentage\\",Fixed=\\"Fixed\\"}
+        
+        
+        export interface CommissionAmountApiModel {
+/**
+ * 
+ * [Deprecated, use 'CommissionAmount' instead]
+ * - Format: decimal
+ * @deprecated Use CommissionAmount instead.
+ */
+\\"comissionAmount\\": number;
+/**
+ * 
+ * کارمزد
+ * - Format: decimal
+ */
+\\"commissionAmount\\": number;
+/**
+ * 
+ * مبلغ اصلی
+ * - Format: decimal
+ */
+\\"requestAmount\\": number;
+/**
+ * 
+ * جمع مبلغ اصلی و کارمزد
+ * - Format: decimal
+ */
+\\"totalAmount\\": number;}
+        
+        
+        export interface CommissionPolicyApiModel {\\"commissionType\\": ComissionType;\\"logicalAction\\": LogicalActionType;\\"commissionTypeDisplay\\"?: string;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"fixedValue\\"?: number;\\"logicalActionDisplay\\"?: string;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"maxValue\\"?: number;
+/**
+ * 
+ * - Format: double
+ */
+\\"percent\\"?: number;\\"title\\"?: string;\\"value\\"?: string;}
+        
+        
+        export interface ContactApiModel {\\"audienceType\\": UserIdentifierType;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"audienceTypeDisplay\\"?: string;\\"contact\\"?: string;\\"fullName\\"?: string;\\"userDisplayName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\"?: string;\\"userProfileImageLink\\"?: string;}
+        
+        
+        export enum DatePart {Minute=\\"Minute\\",Hour=\\"Hour\\",Day=\\"Day\\",Week=\\"Week\\",Month=\\"Month\\",Year=\\"Year\\",All=\\"All\\"}
+        
+        
+        export interface DateReportApiModelOfDecimal {
+/**
+ * 
+ * - Format: int32
+ */
+\\"day\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"key\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"value\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\": number;\\"dayName\\"?: string;\\"label\\"?: string;\\"monthName\\"?: string;}
+        
+        
+        export interface DateReportApiModelOfInteger {
+/**
+ * 
+ * - Format: int32
+ */
+\\"day\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"key\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"value\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\": number;\\"dayName\\"?: string;\\"label\\"?: string;\\"monthName\\"?: string;}
+        
+        
+        export interface DivideEpayRequestServiceInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"expiresAfterDays\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"invoiceDate\\": string;\\"isAutoRedirect\\": boolean;\\"isBlocking\\": boolean;\\"callBackUrl\\"?: string;\\"description\\"?: string;\\"divisions\\"?: DivideEpayRequestShareModel[];\\"invoiceNumber\\"?: string;}
+        
+        
+        export interface DivideEpayRequestShareModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"dividerAmount\\": number;\\"apiKey\\"?: string;\\"invoiceNumber\\"?: string;}
+        
+        
+        export interface DividedEpayRequestCancelInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"dividerAmount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"userAmount\\": number;\\"description\\"?: string;\\"firstName\\"?: string;\\"invoiceNumber\\"?: string;\\"lastName\\"?: string;\\"paymentToken\\"?: string;\\"shebaNo\\"?: string;\\"userApiKey\\"?: string;}
+        
+        
+        export interface DividedEpayRequestCancelResult {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"cancelledAmount\\": number;}
+        
+        
+        export interface DividedEpayRequestUnblockInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"dividerAmount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"userAmount\\": number;\\"description\\"?: string;\\"invoiceNumber\\"?: string;\\"paymentToken\\"?: string;\\"userApiKey\\"?: string;}
+        
+        
+        export interface DividedEpayRequestUnblockResult {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"unblockedAmount\\": number;}
+        
+        
+        export interface DocumentApiModel {\\"contentType\\": DocumentContentType;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDate\\": string;
+/**
+ * 
+ * [Deprecated, use 'ContentType' instead]
+ * @deprecated Use 'ContentType' instead.
+ */
+\\"documentContentType\\":  & (DocumentContentType);
+/**
+ * 
+ * - Format: int64
+ */
+\\"fileSize\\": number;\\"fileType\\": FileTypes;
+/**
+ * 
+ * [Deprecated, use 'FileType' instead]
+ * @deprecated Use 'FileType' instead.
+ */
+\\"fileTypes\\":  & (FileTypes);
+/**
+ * 
+ * - Format: guid
+ */
+\\"uniqueId\\": string;\\"contentTypeDisplay\\"?: string;\\"fileName\\"?: string;\\"fileTypeDisplay\\"?: string;\\"fileUrl\\"?: string;}
+        
+        
+        export enum DocumentContentType {Other=\\"Other\\",UserBankVerification=\\"UserBankVerification\\",IdentityCard=\\"IdentityCard\\",BusinessStatute=\\"BusinessStatute\\",BusinessLatestChangesAnnouncement=\\"BusinessLatestChangesAnnouncement\\",BusinessOwnersIdentityCards=\\"BusinessOwnersIdentityCards\\",BusinessOwnersBirthCertificates=\\"BusinessOwnersBirthCertificates\\"}
+        
+        
+        export interface DocumentInput {\\"documentContentType\\": DocumentContentType;
+/**
+ * 
+ * - Format: guid
+ */
+\\"fileUniqueId\\": string;}
+        
+        
+        export interface DriverInfoResult {\\"barcodType\\": number;\\"barcodTypeDescription\\"?: string;\\"customData\\"?:  & (TaxiInfoOutput);\\"firstName\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"identificationCode\\"?: number;\\"identificationDesc\\"?: string;\\"imageUrl\\"?: string;\\"lastName\\"?: string;\\"nationalCode\\"?: string;\\"price\\"?: TaxiPriceOutput[];}
+        
+        
+        export interface DropDownResultItemOfIdentityStatus {\\"value\\": IdentityStatus;\\"display\\"?: string;}
+        
+        
+        export interface DropDownResultOfIdentityStatus {\\"items\\"?: DropDownResultItemOfIdentityStatus[];}
+        
+        
+        export interface EPayPluginSpecificApiModel {\\"id\\"?: string;\\"persianName\\"?: string;
+/**
+ * 
+ * [Deprecated, don't use this property anymore, it is always null]
+ * @deprecated Don't use this property anymore, it is always null.
+ */
+\\"pluginPropertyId\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'Id' instead]
+ * @deprecated Use 'Id' instead.
+ */
+\\"pluginPropertyName\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'PersianName' instead]
+ * @deprecated Use 'PersianName' instead.
+ */
+\\"pluginPropertyPersianName\\"?: string;\\"value\\"?: string;}
+        
+        
+        export interface EPayRequestAudienceInput {\\"contact\\"?: string;\\"fullName\\"?: string;}
+        
+        
+        export interface EditConnectionInfoInput {\\"position\\"?: string;}
+        
+        
+        export interface EditSubUserPermissionInput {\\"isEnabled\\"?: boolean;\\"subUserPermissionType\\"?:  & (SubUserPermissionType);}
+        
+        
+        export enum EpayRequestActualState {Initiated=\\"Initiated\\",Paid=\\"Paid\\",Cancelled=\\"Cancelled\\",Expired=\\"Expired\\"}
+        
+        
+        export interface EpayRequestApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"epayRequestStatus\\":  & (EpayRequestStatus);
+/**
+ * 
+ * - Format: date-time
+ */
+\\"expireDateTime\\": string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"status\\": EpayRequestActualState;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"assistantDisplayName\\"?: string;\\"assistantPositionTitle\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"assistantUserId\\"?: string;\\"createDate\\"?: string;\\"description\\"?: string;
+/**
+ * 
+ * [Deprecated, don't use EpayRequestAudience]
+ * @deprecated Don't use EpayRequestAudience.
+ */
+\\"epayRequestAudience\\"?: EPayRequestAudienceInput[];\\"expireDate\\"?: string;\\"payDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"payDateTime\\"?: string;\\"payerName\\"?: string;\\"paymentLink\\"?: string;\\"qrCodeLink\\"?: string;\\"statusDisplay\\"?: string;\\"targetDisplayName\\"?: string;\\"userAccountName\\"?: string;}
+        
+        
+        export interface EpayRequestCheckStatusResult {\\"requestStatus\\": EpayRequestStatus;\\"bankReferenceId\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"verifyDate\\"?: string;}
+        
+        
+        export interface EpayRequestDetailApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * [Deprecated, use 'CommissionAmount' instead]
+ * - Format: decimal
+ * @deprecated Use 'CommissionAmount' instead.
+ */
+\\"comissionAmount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionAmount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"epayRequestStatus\\":  & (EpayRequestStatus);
+/**
+ * 
+ * - Format: date-time
+ */
+\\"expireDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'GetCommissionFromPayer' instead]
+ * @deprecated Use 'GetCommissionFromPayer' instead.
+ */
+\\"getComissionByPayer\\": boolean;\\"getCommissionFromPayer\\": boolean;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"status\\": EpayRequestActualState;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"assistantDisplayName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"assistantUserId\\"?: string;\\"audiences\\"?: ContactApiModel[];\\"description\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'Audiences' instead]
+ * @deprecated Use 'Audiences' instead.
+ */
+\\"epayRequestAudience\\"?: ContactApiModel[];
+/**
+ * 
+ * [Deprecated, use 'PluginProperties' instead]
+ * @deprecated Use 'PluginProperties' instead.
+ */
+\\"epayRequestPluginSpecific\\"?: EPayPluginSpecificApiModel[];
+/**
+ * 
+ * - Format: date-time
+ */
+\\"payDateTime\\"?: string;\\"paymentLink\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"pluginId\\"?: number;\\"pluginName\\"?: string;\\"pluginProperties\\"?: EPayPluginSpecificApiModel[];\\"publicLink\\"?: string;\\"qrCodeLink\\"?: string;\\"statusDisplay\\"?: string;\\"token\\"?: string;\\"userAccountName\\"?: string;}
+        
+        
+        export interface EpayRequestForUserQuery {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * [Deprecated, don't use this property anymore]
+ * @deprecated Don't use this property anymore.
+ */
+\\"canBeCanceled\\": boolean;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"epayRequestStatus\\":  & (EpayRequestStatus);
+/**
+ * 
+ * - Format: date-time
+ */
+\\"expireDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'Token' for EPays that created by others]
+ * - Format: int64
+ * @deprecated Use 'Token' for EPays that created by others.
+ */
+\\"id\\": number;\\"status\\": EpayRequestActualState;
+/**
+ * 
+ * [Deprecated, use 'UserDisplayName' instead]
+ * @deprecated Use 'UserDisplayName' instead.
+ */
+\\"applicantName\\"?: string;\\"createDate\\"?: string;\\"description\\"?: string;\\"expireDate\\"?: string;\\"paymentUrl\\"?: string;\\"statusDisplay\\"?: string;\\"token\\"?: string;\\"userAccountNumber\\"?: string;\\"userDisplayName\\"?: string;}
+        
+        
+        export interface EpayRequestPayInput {\\"description\\"?: string;}
+        
+        
+        export interface EpayRequestPluginSpecificInput {\\"pluginPropertyId\\"?: string;\\"value\\"?: string;}
+        
+        
+        export interface EpayRequestPublicInfoApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"expireDate\\": string;\\"status\\": EpayRequestStatus;\\"description\\"?: string;\\"expireDateDisplay\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"payDate\\"?: string;\\"payDateDisplay\\"?: string;\\"payerName\\"?: string;\\"paymentUrl\\"?: string;\\"statusDisplay\\"?: string;\\"token\\"?: string;\\"userAccountNumber\\"?: string;\\"userAvatarUrl\\"?: string;\\"userDisplayName\\"?: string;}
+        
+        
+        export interface EpayRequestServiceInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"callbackType\\": CallbackType;
+/**
+ * 
+ * - Format: guid
+ */
+\\"clientId\\": string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"domainId\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"expiresAfterDays\\": number;\\"getComissionFromPayer\\": boolean;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"invoiceDate\\": string;\\"isAutoConfirm\\": boolean;\\"isAutoRedirect\\": boolean;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userAccountId\\": number;
+/**
+ * 
+ * - Format: guid
+ * - minLength: 1
+ */
+\\"userId\\": string;\\"audiences\\"?: EPayRequestAudienceInput[];\\"callbackUrl\\"?: string;\\"description\\"?: string;\\"invoiceNumber\\"?: string;}
+        
+        
+        export enum EpayRequestStatus {Initiated=\\"Initiated\\",Paid=\\"Paid\\",Cancelled=\\"Cancelled\\",Expired=\\"Expired\\",Viewed=\\"Viewed\\"}
+        
+        
+        export interface EpayRequestTaskInput {\\"epayRequestTaskType\\": EpayRequestTaskType;}
+        
+        
+        export enum EpayRequestTaskType {Resend=\\"Resend\\",Cancel=\\"Cancel\\"}
+        
+        
+        export enum EpayRequestType {Link=\\"Link\\",POS=\\"POS\\",Divide=\\"Divide\\",DivideWithBlock=\\"DivideWithBlock\\",Charge=\\"Charge\\",IPG=\\"IPG\\"}
+        
+        
+        export interface EpayRequestWcfResult {\\"paymentUrl\\"?: string;\\"requestToken\\"?: string;}
+        
+        
+        export enum FieldDisplayType {String=\\"String\\",Text=\\"Text\\",Currency=\\"Currency\\",Integer=\\"Integer\\",Float=\\"Float\\",Boolean=\\"Boolean\\",List=\\"List\\"}
+        
+        
+        export interface FileApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"fileSize\\": number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"uniqueId\\": string;\\"fileName\\"?: string;\\"fileUrl\\"?: string;}
+        
+        
+        export enum FileTypes {Other=\\"Other\\",Image=\\"Image\\",Pdf=\\"Pdf\\"}
+        
+        
+        export interface ForgetPasswordQuery {\\"token\\"?: string;}
+        
+        
+        export interface FullRegisterApiModel {\\"fullName\\"?: string;\\"introducerCode\\"?: string;\\"phoneNumber\\"?: string;}
+        
+        
+        export enum Gender {Unknown=\\"Unknown\\",Male=\\"Male\\",Female=\\"Female\\"}
+        
+        
+        export interface GetBusinessUserConnectionActiveQueryParams {
+/**
+ * 
+ * defaults to 0
+ * - Format: int32
+ */
+\\"skip\\"?: number;
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;}
+        
+        
+        export interface GetBusinessUserConnectionConnectionIdEpayQueryParams {
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endDate\\"?: string;\\"epayRequestStatus\\"?: \\"Initiated\\" | \\"Paid\\" | \\"Cancelled\\" | \\"Expired\\" | \\"Viewed\\";
+/**
+ * 
+ * - Format: int32
+ */
+\\"pluginId\\"?: number;\\"plugin_SepidarCustomerName\\"?: string;\\"plugin_SepidarCustomerNumber\\"?: string;\\"plugin_SepidarDocumentNumber\\"?: string;\\"plugin_SepidarVoucherType\\"?: string;\\"plugin_ZhenicCustomerName\\"?: string;\\"plugin_ZhenicCustomerNumber\\"?: string;\\"plugin_ZhenicDollarAmount\\"?: string;\\"plugin_ZhenicDollarAmountRate\\"?: string;\\"plugin_ZhenicEuroAmount\\"?: string;\\"plugin_ZhenicEuroAmountRate\\"?: string;\\"plugin_ZhenicInvoiceNumber\\"?: string;\\"plugin_ZhenicRialAmount\\"?: string;
+/**
+ * 
+ * defaults to 0
+ * - Format: int32
+ */
+\\"skip\\"?: number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startDate\\"?: string;
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface GetBusinessUserConnectionQueryParams {
+/**
+ * 
+ * defaults to 0
+ * - Format: int32
+ */
+\\"skip\\"?: number;\\"states\\"?:  & (SubUserConnectionStatus)[];\\"subUserConnectionStatus\\"?: \\"Pending\\" | \\"Rejected\\" | \\"Connected\\" | \\"Disconnected\\" | \\"Deleted\\";
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;}
+        
+        
+        export interface GetEpayRequestCountQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Year\\"?: number;}
+        
+        
+        export interface GetEpayRequestExcelQueryParams {\\"accountIds\\"?: number[];
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endDate\\"?: string;\\"epayRequestStatus\\"?: \\"Initiated\\" | \\"Paid\\" | \\"Cancelled\\" | \\"Expired\\" | \\"Viewed\\";
+/**
+ * 
+ * - Format: int32
+ */
+\\"pluginId\\"?: number;\\"plugin_SepidarCustomerName\\"?: string;\\"plugin_SepidarCustomerNumber\\"?: string;\\"plugin_SepidarDocumentNumber\\"?: string;\\"plugin_SepidarVoucherType\\"?: string;\\"plugin_ZhenicCustomerName\\"?: string;\\"plugin_ZhenicCustomerNumber\\"?: string;\\"plugin_ZhenicDollarAmount\\"?: string;\\"plugin_ZhenicDollarAmountRate\\"?: string;\\"plugin_ZhenicEuroAmount\\"?: string;\\"plugin_ZhenicEuroAmountRate\\"?: string;\\"plugin_ZhenicInvoiceNumber\\"?: string;\\"plugin_ZhenicRialAmount\\"?: string;
+/**
+ * 
+ * defaults to 0
+ * - Format: int32
+ */
+\\"skip\\"?: number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startDate\\"?: string;\\"states\\"?:  & (EpayRequestActualState)[];
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface GetEpayRequestForMeCountQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Year\\"?: number;}
+        
+        
+        export interface GetEpayRequestForMeQueryParams {\\"applicantName\\"?: string;\\"applicantPhoneNumber\\"?: string;\\"endDate\\"?: string;
+/**
+ * 
+ * obsoleted
+ */
+\\"epayRequestStatus\\"?: \\"Initiated\\" | \\"Paid\\" | \\"Cancelled\\" | \\"Expired\\" | \\"Viewed\\";
+/**
+ * 
+ * defaults to 0
+ * - Format: int32
+ */
+\\"skip\\"?: number;\\"startDate\\"?: string;\\"states\\"?:  & (EpayRequestActualState)[];
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;}
+        
+        
+        export interface GetEpayRequestForMeReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Year\\"?: number;}
+        
+        
+        export interface GetEpayRequestPosQrAccountNumberQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"subUserConId\\"?: number;}
+        
+        
+        export interface GetEpayRequestQueryParams {\\"accountIds\\"?: number[];
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endDate\\"?: string;\\"epayRequestStatus\\"?: \\"Initiated\\" | \\"Paid\\" | \\"Cancelled\\" | \\"Expired\\" | \\"Viewed\\";
+/**
+ * 
+ * - Format: int32
+ */
+\\"pluginId\\"?: number;\\"plugin_SepidarCustomerName\\"?: string;\\"plugin_SepidarCustomerNumber\\"?: string;\\"plugin_SepidarDocumentNumber\\"?: string;\\"plugin_SepidarVoucherType\\"?: string;\\"plugin_ZhenicCustomerName\\"?: string;\\"plugin_ZhenicCustomerNumber\\"?: string;\\"plugin_ZhenicDollarAmount\\"?: string;\\"plugin_ZhenicDollarAmountRate\\"?: string;\\"plugin_ZhenicEuroAmount\\"?: string;\\"plugin_ZhenicEuroAmountRate\\"?: string;\\"plugin_ZhenicInvoiceNumber\\"?: string;\\"plugin_ZhenicRialAmount\\"?: string;
+/**
+ * 
+ * defaults to 0
+ * - Format: int32
+ */
+\\"skip\\"?: number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startDate\\"?: string;\\"states\\"?:  & (EpayRequestActualState)[];
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface GetEpayRequestReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Year\\"?: number;}
+        
+        
+        export interface GetEpayRequestUserWalletIdCommissionQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;}
+        
+        
+        export interface GetGroupTransferCommissionQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface GetIntegrationQueryParams {
+/**
+ * 
+ * code of the corresponding institude
+ * - Format: int32
+ */
+\\"instituteCode\\"?: number;
+/**
+ * 
+ * code specific to each driver
+ */
+\\"termainalId\\"?: string;}
+        
+        
+        export interface GetKpiCurrentQueryParams {\\"datePart\\"?: DatePart[];\\"kpiName\\"?: string[];}
+        
+        
+        export interface GetKpiLastQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"count\\"?: number;\\"datePart\\"?: DatePart[];\\"endPartial\\"?: boolean;\\"kpiName\\"?: string[];}
+        
+        
+        export interface GetKpiQueryParams {\\"datePart\\"?: DatePart[];
+/**
+ * 
+ * - Format: date-time
+ */
+\\"end\\"?: string;\\"endPartial\\"?: boolean;\\"kpiName\\"?: string[];
+/**
+ * 
+ * - Format: date-time
+ */
+\\"start\\"?: string;\\"startPartial\\"?: boolean;}
+        
+        
+        export interface GetNotificationUnreadQueryParams {\\"channels\\"?: NotificationChannel[];}
+        
+        
+        export interface GetPosAccountNumberQueryParams {
+/**
+ * 
+ * Subuser Connection Id
+ * - Format: int64
+ */
+\\"subUserConId\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardCommissionReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardCommissionSumQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardIntroducedCountQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardIntroducedReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardLinksCountQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardLinksPaidCountQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardLinksPaidReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardLinksReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardTransactionsCountQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserDashboardTransactionsReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"fromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"takeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"toYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\"?: number;}
+        
+        
+        export interface GetResellerUserIntroducedQueryParams {\\"identityStatuses\\"?: IdentityStatus[];\\"isActive\\"?: boolean;\\"isPerson\\"?: boolean;
+/**
+ * 
+ * YYYY-MM-DD
+ * - Format: date-time
+ */
+\\"lastActivityFrom\\"?: string;
+/**
+ * 
+ * YYYY-MM-DD
+ * - Format: date-time
+ */
+\\"lastActivityTo\\"?: string;\\"orderBy\\"?: string;\\"orderDesc\\"?: boolean;
+/**
+ * 
+ * YYYY-MM-DD
+ * - Format: date-time
+ */
+\\"registeredFrom\\"?: string;
+/**
+ * 
+ * YYYY-MM-DD
+ * - Format: date-time
+ */
+\\"registeredTo\\"?: string;\\"searchInput\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"skip\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"take\\"?: number;}
+        
+        
+        export interface GetTransactionExcelQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amountFrom\\"?: number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amountTo\\"?: number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endDate\\"?: string;\\"logicalActions\\"?:  & (LogicalActionType)[];\\"operationType\\"?: \\"Unknown\\" | \\"Normal\\" | \\"System\\" | \\"DomainCommission\\" | \\"ResellerCommission\\" | \\"Block\\" | \\"Unblock\\" | \\"Refund\\" | \\"NoCommissionRemainGift\\" | \\"RemainGift\\" | \\"DomainBankBatchTransfer\\" | \\"SettlementBatchTransferItem\\" | \\"Synchronization\\" | \\"BlockchainWithdrawInternalTransfer\\" | \\"BlockchainWithdrawUserWallet\\" | \\"BlockchainIncomingTransaction\\" | \\"BlockchainWithdrawUserWalletOffchain\\" | \\"BlockchainFee\\";\\"operationTypes\\"?:  & (TransactionOperationType)[];
+/**
+ * 
+ * - Format: int32
+ */
+\\"skip\\"?: number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startDate\\"?: string;
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;\\"transactionType\\"?: \\"Debt\\" | \\"Credit\\";\\"transactionTypes\\"?:  & (TransactionType)[];
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;\\"voucherTypes\\"?:  & (VoucherOperationType)[];}
+        
+        
+        export interface GetTransactionQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amountFrom\\"?: number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amountTo\\"?: number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endDate\\"?: string;
+/**
+ * 
+ * deprecated. use 'take' instead.
+ * - Format: int32
+ */
+\\"limit\\"?: number;\\"logicalActions\\"?:  & (LogicalActionType)[];\\"operationType\\"?: \\"Unknown\\" | \\"Normal\\" | \\"System\\" | \\"DomainCommission\\" | \\"ResellerCommission\\" | \\"Block\\" | \\"Unblock\\" | \\"Refund\\" | \\"NoCommissionRemainGift\\" | \\"RemainGift\\" | \\"DomainBankBatchTransfer\\" | \\"SettlementBatchTransferItem\\" | \\"Synchronization\\" | \\"BlockchainWithdrawInternalTransfer\\" | \\"BlockchainWithdrawUserWallet\\" | \\"BlockchainIncomingTransaction\\" | \\"BlockchainWithdrawUserWalletOffchain\\" | \\"BlockchainFee\\";\\"operationTypes\\"?:  & (TransactionOperationType)[];
+/**
+ * 
+ * - Format: int32
+ */
+\\"skip\\"?: number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startDate\\"?: string;
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;\\"transactionType\\"?: \\"Debt\\" | \\"Credit\\";\\"transactionTypes\\"?:  & (TransactionType)[];
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;\\"voucherTypes\\"?:  & (VoucherOperationType)[];}
+        
+        
+        export interface GetTransactionReportAllQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Year\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"accountId\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"businessCategoryId\\"?: number;\\"operationType\\"?: \\"Unknown\\" | \\"Normal\\" | \\"System\\" | \\"DomainCommission\\" | \\"ResellerCommission\\" | \\"Block\\" | \\"Unblock\\" | \\"Refund\\" | \\"NoCommissionRemainGift\\" | \\"RemainGift\\" | \\"DomainBankBatchTransfer\\" | \\"SettlementBatchTransferItem\\" | \\"Synchronization\\" | \\"BlockchainWithdrawInternalTransfer\\" | \\"BlockchainWithdrawUserWallet\\" | \\"BlockchainIncomingTransaction\\" | \\"BlockchainWithdrawUserWalletOffchain\\" | \\"BlockchainFee\\";\\"type\\"?: \\"Debt\\" | \\"Credit\\";}
+        
+        
+        export interface GetTransactionReportQueryParams {
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"FromYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Month\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeDays\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeMonths\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"TakeYears\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToMonth\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"ToYear\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"Year\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"accountId\\"?: number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"businessCategoryId\\"?: number;\\"operationType\\"?: \\"Unknown\\" | \\"Normal\\" | \\"System\\" | \\"DomainCommission\\" | \\"ResellerCommission\\" | \\"Block\\" | \\"Unblock\\" | \\"Refund\\" | \\"NoCommissionRemainGift\\" | \\"RemainGift\\" | \\"DomainBankBatchTransfer\\" | \\"SettlementBatchTransferItem\\" | \\"Synchronization\\" | \\"BlockchainWithdrawInternalTransfer\\" | \\"BlockchainWithdrawUserWallet\\" | \\"BlockchainIncomingTransaction\\" | \\"BlockchainWithdrawUserWalletOffchain\\" | \\"BlockchainFee\\";\\"type\\"?: \\"Debt\\" | \\"Credit\\";}
+        
+        
+        export interface GetTransferRecentQueryParams {
+/**
+ * 
+ * defaults to 10
+ * - Format: int32
+ */
+\\"take\\"?: number;}
+        
+        
+        export interface GetTransferSearchQueryParams {\\"accountNumber\\"?: string;
+/**
+ * 
+ * Phone number or email address
+ */
+\\"contact\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"customerNumber\\"?: number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface GetTransferUserWalletIdCommissionQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;}
+        
+        
+        export interface GetUserWalletAccountNumberQrcodeQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"subUserConId\\"?: number;}
+        
+        
+        export interface GetUserWalletSearchQueryParams {\\"accountNumber\\"?: string;\\"contact\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"customerNumber\\"?: number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface GetUserWalletUserWalletIdEpayRequestComissionQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;}
+        
+        
+        export interface GetUserWalletUserWalletIdSettlementRequestComissionQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;}
+        
+        
+        export interface GetUserWalletUserWalletIdTransferMoneyCommissionQueryParams {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\"?: number;}
+        
+        
+        export interface GroupTransferInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"totalAmount\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"description\\"?: string;\\"targets\\"?: GroupTransferTargetInput[];}
+        
+        
+        export interface GroupTransferQuery {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDate\\": string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"voucherId\\": number;\\"createDateDisplay\\"?: string;\\"description\\"?: string;\\"targets\\"?: GroupTransferTargetQuery[];\\"userAccountName\\"?: string;\\"userDisplayName\\"?: string;}
+        
+        
+        export interface GroupTransferTargetInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"description\\"?: string;\\"identifier\\"?: string;}
+        
+        
+        export interface GroupTransferTargetQuery {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"accountName\\"?: string;\\"description\\"?: string;\\"userDisplayName\\"?: string;\\"userPhoneNumber\\"?: string;}
+        
+        
+        export enum GroupTransferTargetStatus {InvalidIdentifier=\\"InvalidIdentifier\\",Ok=\\"Ok\\",Unregistered=\\"Unregistered\\",BlockedAccount=\\"BlockedAccount\\",InvalidAmount=\\"InvalidAmount\\"}
+        
+        
+        export interface GroupTransferTargetValidationInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"description\\"?: string;
+/**
+ * 
+ * PhoneNumber or Account Number
+ */
+\\"identifier\\"?: string;}
+        
+        
+        export interface GroupTransferTargetValidationQuery {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"identifierType\\": UserIdentifierType;\\"status\\": GroupTransferTargetStatus;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userCustomerNumber\\": number;\\"accountNumber\\"?: string;\\"identifier\\"?: string;\\"identifierTypeDisplay\\"?: string;\\"name\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'StatusDisplay' instead]
+ * @deprecated Use 'StatusDisplay' instead.
+ */
+\\"statusDescription\\"?: string;\\"statusDisplay\\"?: string;\\"userDisplayName\\"?: string;\\"userPhoneNumber\\"?: string;}
+        
+        
+        export enum IPGStatus {NotRequested=\\"NotRequested\\"}
+        
+        
+        export enum IdentityStatus {None=\\"None\\",WatingForCheck=\\"WatingForCheck\\",Checking=\\"Checking\\",EditingRequired=\\"EditingRequired\\",Approved=\\"Approved\\",Rejected=\\"Rejected\\"}
+        
+        
+        export interface ImportantActionApiModel {\\"closeable\\": boolean;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createTime\\": string;\\"dismissible\\": boolean;
+/**
+ * 
+ * - Format: int32
+ */
+\\"id\\": number;\\"isSeen\\": boolean;\\"level\\": NotificationLevel;\\"type\\": NotificationModelType;\\"data\\"?: string;\\"dataId\\"?: string;\\"levelDisplay\\"?: string;\\"text\\"?: string;\\"title\\"?: string;\\"typeDisplay\\"?: string;}
+        
+        
+        export interface InitApiModel {\\"versionState\\": TerminalVersionState;\\"appDownloadLink\\"?: string;\\"versionStateDisplay\\"?: string;}
+        
+        
+        export interface KpiResult {
+/**
+ * 
+ * - Format: date-time
+ */
+\\"end\\": string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"start\\": string;\\"datePart\\"?:  & (DatePart);\\"kpiName\\"?: string;\\"targetIds\\"?: string[];\\"values\\"?: KpiResultValue[];}
+        
+        
+        export interface KpiResultValue {
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endPoint\\": string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"extractedTime\\": string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startPoint\\": string;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"value\\": number;\\"targetId\\"?: string;}
+        
+        
+        export enum LogEventLevel {Verbose=\\"Verbose\\",Debug=\\"Debug\\",Information=\\"Information\\",Warning=\\"Warning\\",Error=\\"Error\\",Fatal=\\"Fatal\\"}
+        
+        
+        export interface LogSetting {\\"globalLogLevel\\": LogEventLevel;\\"septaPayLogLevel\\": LogEventLevel;\\"serilogLogLevel\\": LogEventLevel;}
+        
+        
+        export enum LogicalActionType {EpayRequest=\\"EpayRequest\\",TransferMoney=\\"TransferMoney\\",AccountChargeRequest=\\"AccountChargeRequest\\",ServiceBill=\\"ServiceBill\\",ServiceMobileCharge=\\"ServiceMobileCharge\\",POS=\\"POS\\",ShareAndBlockRequest=\\"ShareAndBlockRequest\\",ShareRequest=\\"ShareRequest\\",Settlement=\\"Settlement\\",GroupTransferMoney=\\"GroupTransferMoney\\",ShareAndUnblock=\\"ShareAndUnblock\\",Refund=\\"Refund\\",PayCommand=\\"PayCommand\\",Gift=\\"Gift\\",TaxiFairPayment=\\"TaxiFairPayment\\",HitoBitFee=\\"HitoBitFee\\"}
+        
+        
+        export interface MachineSignUp {
+/**
+ * 
+ * - Format: int64
+ */
+\\"customerNumber\\": number;\\"apiKey\\"?: string;}
+        
+        
+        export interface NewChargeRequestInput {
+/**
+ * 
+ * مبلغ شارژ
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * آدرس بازگشت بعد از پرداخت
+ */
+\\"callbackUrl\\"?: string;}
+        
+        
+        export interface NewChargeRequestResultQuery {\\"paymentLink\\"?: string;}
+        
+        
+        export interface NewEpayRequestInput {
+/**
+ * 
+ * مبلغ شارژ
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * نوع ارجاع در هنگام ایجاد درخواست
+ */
+\\"callbackType\\":  & (CallbackType);
+/**
+ * 
+ * تاریخ انتقضا لینک ایجاد شده
+ * - Format: int32
+ */
+\\"expireDays\\": number;
+/**
+ * 
+ * انتقال مستقیم به درگاه
+ 
+ */
+\\"isAutoConfirm\\": boolean;
+/**
+ * 
+ * - Format: guid
+ */
+\\"assisstantUserId\\"?: string;
+/**
+ * 
+ * اطلاعات پرداخت کننده / ها
+ */
+\\"audiences\\"?: EPayRequestAudienceInput[];
+/**
+ * 
+ * آدرس بازگشت بعد از پرداخت
+ */
+\\"callbackUrl\\"?: string;
+/**
+ * 
+ * توضحیات درخواست (بابت)
+ */
+\\"description\\"?: string;
+/**
+ * 
+ * نحوه دریافت کارمزد
+ */
+\\"getComissionByPayer\\"?: boolean;
+/**
+ * 
+ * تاریخ فاکتور
+ * - Format: date-time
+ */
+\\"invoiceDate\\"?: string;
+/**
+ * 
+ * شماره فاکتور
+ */
+\\"invoiceNumber\\"?: string;
+/**
+ * 
+ * ...
+ * - Format: int32
+ */
+\\"pluginId\\"?: number;
+/**
+ * 
+ * ...
+ */
+\\"pluginSpecifics\\"?: EpayRequestPluginSpecificInput[];}
+        
+        
+        export interface NewUserIdentityRequestInput {\\"documents\\"?: DocumentInput[];\\"firstName\\"?: string;\\"lastName\\"?: string;\\"nationalCode\\"?: string;}
+        
+        
+        export interface NotificationApiModel {
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createTime\\": string;\\"isSeen\\": boolean;\\"level\\": NotificationLevel;\\"type\\": NotificationModelType;\\"dataId\\"?: string;\\"levelDisplay\\"?: string;\\"text\\"?: string;\\"title\\"?: string;\\"typeDisplay\\"?: string;}
+        
+        
+        export enum NotificationChannel {Notification=\\"Notification\\",ImportantAction=\\"ImportantAction\\",SMS=\\"SMS\\",Email=\\"Email\\",FCM=\\"FCM\\",SignalR=\\"SignalR\\"}
+        
+        
+        export enum NotificationLevel {Unknown=\\"Unknown\\",Default=\\"Default\\",Success=\\"Success\\",Info=\\"Info\\",Warning=\\"Warning\\",Danger=\\"Danger\\"}
+        
+        
+        export enum NotificationModelType {Default=\\"Default\\",EPayRequestUnpaid=\\"EPayRequestUnpaid\\",EPayRequestPaid=\\"EPayRequestPaid\\",UserIdentityUnknown=\\"UserIdentityUnknown\\",UserIdentityApproved=\\"UserIdentityApproved\\",UserIdentityRejected=\\"UserIdentityRejected\\",UpgradeToBusinessApproved=\\"UpgradeToBusinessApproved\\",UpgradeToBusinessRejected=\\"UpgradeToBusinessRejected\\",UserBankApproved=\\"UserBankApproved\\",UserBankRejected=\\"UserBankRejected\\",SubUserConnectionCreated=\\"SubUserConnectionCreated\\",SubUserInvitationRejected=\\"SubUserInvitationRejected\\",SubUserInvitationSent=\\"SubUserInvitationSent\\",MoneyDeposit=\\"MoneyDeposit\\",MoneyWithdrawal=\\"MoneyWithdrawal\\",SubUserDisconnectedByBusiness=\\"SubUserDisconnectedByBusiness\\",SubUserDisconnectedBySubUser=\\"SubUserDisconnectedBySubUser\\",Activities=\\"Activities\\",TradeNotification=\\"TradeNotification\\",HitoBitNews=\\"HitoBitNews\\",SystemMessages=\\"SystemMessages\\"}
+        
+        
+        export enum PlatformType {Unknown=\\"Unknown\\",Server=\\"Server\\",Android=\\"Android\\",iOS=\\"iOS\\",Device=\\"Device\\",Browser=\\"Browser\\",PWA=\\"PWA\\",Web=\\"Web\\",Windows=\\"Windows\\",Linux=\\"Linux\\",macOS=\\"macOS\\",Desktop=\\"Desktop\\"}
+        
+        
+        export interface PluginApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"id\\": number;\\"amountCalculationExpression\\"?: string;\\"logoFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"logoFileUniqueId\\"?: string;\\"logoFileUrl\\"?: string;\\"name\\"?: string;\\"properties\\"?: PluginPropertyApiModel[];}
+        
+        
+        export interface PluginPropertyApiModel {\\"fieldType\\": FieldDisplayType;\\"isFilterable\\": boolean;\\"isRequired\\": boolean;\\"currencyName\\"?: string;\\"description\\"?: string;\\"name\\"?: string;\\"title\\"?: string;\\"value\\"?: string;}
+        
+        
+        export interface PosLandingPageApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"domainId\\": number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"accountNumber\\"?: string;\\"domainEnglishName\\"?: string;\\"domainLogoFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"domainLogoFileUniqueId\\"?: string;\\"domainLogoFileUrl\\"?: string;\\"domainPersianName\\"?: string;\\"getCommissionFromPayer\\"?: boolean;\\"subUserAvatarFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"subUserAvatarFileUniqueId\\"?: string;\\"subUserAvatarFileUrl\\"?: string;\\"subUserDisplayName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"subUserId\\"?: string;\\"userAvatarFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userAvatarFileUniqueId\\"?: string;\\"userAvatarFileUrl\\"?: string;\\"userDisplayName\\"?: string;}
+        
+        
+        export interface PosOnlinePayInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"callBackUrl\\"?: string;\\"callbackType\\"?:  & (CallbackType);\\"description\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"subuserId\\"?: string;}
+        
+        
+        export interface PosWalletPayInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"description\\"?: string;}
+        
+        
+        export interface RegisterApiModel {\\"deviceBrandName\\"?: string;\\"deviceId\\"?: string;\\"deviceOsVersion\\"?: string;\\"deviceToken\\"?: string;\\"phoneNumber\\"?: string;}
+        
+        
+        export interface RegisterNewUserQuery {
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"token\\"?: string;}
+        
+        
+        export interface ReportApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"count\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"day\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"dayOfWeek\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"key\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"sum\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\": number;\\"dayName\\"?: string;\\"label\\"?: string;\\"monthName\\"?: string;
+/**
+ * 
+ * سال دو رقمی
+ */
+\\"yearShort\\"?: string;}
+        
+        
+        export type RequestBodyAccountCreationApiModel = AccountCreationApiModel
+        
+        
+        export interface RequestBodyFile_Upload {
+/**
+ * 
+ * - Format: binary
+ */
+\\"file\\"?: string;}
+        
+        
+        export type RequestBodyLogEventLevel = LogEventLevel
+        
+        
+        export type RequestBodyNewEpayRequestInput = NewEpayRequestInput
+        
+        
+        export type RequestBodySubUserNotificationStatusInput = SubUserNotificationStatusInput
+        
+        
+        export type RequestBodyTransferMoneyInput = TransferMoneyInput
+        
+        
+        export type RequestBodyUserBankInput = UserBankInput
+        
+        
+        export interface RequestTotpInput {\\"phoneNumber\\"?: string;}
+        
+        
+        export interface ReselledUserActivityApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"commissionsPaidToResellerCount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionsPaidToResellerSum\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"generatedLinks\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"paidGeneratedLinks\\": number;}
+        
+        
+        export interface ReselledUserApiModel {\\"identityStatus\\": IdentityStatus;\\"ipgStatus\\": IPGStatus;\\"isActive\\": boolean;\\"isBussinessUser\\": boolean;\\"isPerson\\": boolean;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"userStatus\\": UserStatus;\\"displayName\\"?: string;\\"identityStatusDisplay\\"?: string;\\"imageUrl\\"?: string;\\"ipgStatusDisplay\\"?: string;\\"lastActivityDate\\"?: string;\\"phoneNumber\\"?: string;\\"registerDate\\"?: string;}
+        
+        
+        export interface ReselledUserFilterData {\\"identityStatuses\\"?:  & (DropDownResultOfIdentityStatus);}
+        
+        
+        export interface ResellerApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"commissionId\\": number;\\"commissionType\\": ComissionType;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endDate\\": string;\\"hasSubDomain\\": boolean;\\"isActive\\": boolean;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startDate\\": string;\\"commissionDisplay\\"?: string;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionFixedValue\\"?: number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionMaxValue\\"?: number;\\"commissionName\\"?: string;
+/**
+ * 
+ * - Format: double
+ */
+\\"commissionPercent\\"?: number;\\"commissionTypeDisplay\\"?: string;\\"endDateDisplay\\"?: string;\\"introduceLink\\"?: string;\\"startDateDisplay\\"?: string;}
+        
+        
+        export interface SendConnectionRequestInput {\\"email\\"?: string;\\"phoneNumber\\"?: string;\\"position\\"?: string;}
+        
+        
+        export enum SepidResponseType {Succesful=\\"Succesful\\",Unsuccesful=\\"Unsuccesful\\"}
+        
+        
+        export interface SetAccountAccessForSubUserInput {
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface SetUserBasicInfoInput {
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"firstName\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"introducerCode\\"?: number;\\"lastName\\"?: string;\\"password\\"?: string;}
+        
+        
+        export interface SettingApiModel {\\"logSetting\\"?:  & (LogSetting);}
+        
+        
+        export interface SubDomainApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"domainId\\": number;\\"isActive\\": boolean;
+/**
+ * 
+ * - Format: guid
+ */
+\\"resellerUserId\\": string;\\"about\\"?: string;\\"domainEnglishName\\"?: string;\\"domainPersianName\\"?: string;\\"englishName\\"?: string;\\"logoFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"logoFileUniqueId\\"?: string;\\"logoFileUrl\\"?: string;\\"persianName\\"?: string;\\"resellerUserDisplayName\\"?: string;\\"subDomainAddress\\"?: string;}
+        
+        
+        export interface SubDomainUpdateApiModel {\\"about\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"logoFileUniqueId\\"?: string;}
+        
+        
+        export interface SubUserAccountDetailQuery {\\"accountStatus\\": AccountStatus;\\"canAssistantsCreatesEpayRequest\\": boolean;\\"canChargeAccount\\": boolean;\\"canReceiveMoney\\": boolean;\\"canRequestSettlement\\": boolean;\\"canSeeEpayRequests\\": boolean;\\"canSeeSettlementRequests\\": boolean;\\"canSeeTransactions\\": boolean;\\"canTransferMoney\\": boolean;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"isActive\\": boolean;\\"notificationEnabled\\": boolean;
+/**
+ * 
+ * - Format: int32
+ */
+\\"posPaidCount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"posScanCount\\": number;\\"accountNumber\\"?: string;\\"accountQrCodeUrl\\"?: string;\\"accountStatusDisplay\\"?: string;\\"name\\"?: string;\\"posLinkUrl\\"?: string;}
+        
+        
+        export interface SubUserActivityApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"accountChargeRequestAmount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"accountChargeRequestCount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"paidEpayRequestAmount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"paidEpayRequestCount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"settlementRequestAmount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"settlementRequestCount\\": number;}
+        
+        
+        export interface SubUserConnectionApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"invitationId\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"requestDateTime\\": string;\\"status\\": SubUserConnectionStatus;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead,
+ */
+\\"subUserConnectionStatus\\":  & (SubUserConnectionStatus);\\"connectDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"connectDateTime\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"connectionId\\"?: number;\\"disconnectDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"disconnectDateTime\\"?: string;\\"removeDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"removeDateTime\\"?: string;\\"requestDate\\"?: string;\\"statusDisplay\\"?: string;\\"subUserAvatarUrl\\"?: string;\\"subUserContact\\"?: string;\\"subUserPositionTitle\\"?: string;\\"subUserTitle\\"?: string;}
+        
+        
+        export enum SubUserConnectionStatus {Pending=\\"Pending\\",Rejected=\\"Rejected\\",Connected=\\"Connected\\",Disconnected=\\"Disconnected\\",Deleted=\\"Deleted\\"}
+        
+        
+        export interface SubUserInvitationApiModel {
+/**
+ * 
+ * - Format: date-time
+ */
+\\"invitationDate\\": string;
+/**
+ * 
+ * [Deprecated, use 'InvitationToken' to call new endpoints]
+ * - Format: int64
+ * @deprecated Use 'InvitationToken' to call new endpoints.
+ */
+\\"invitationId\\": number;\\"businessUserAvatarUrl\\"?: string;\\"businessUserTitle\\"?: string;\\"invitationToken\\"?: string;\\"message\\"?: string;}
+        
+        
+        export interface SubUserNotificationStatusInput {\\"notificationEnabled\\": boolean;}
+        
+        
+        export interface SubUserPermissionApiModel {\\"canAccessToAccount\\": boolean;\\"canAssistantsCreatesEpayRequest\\": boolean;\\"canChargeAccount\\": boolean;\\"canGroupTransferMoney\\": boolean;\\"canReceiveMoney\\": boolean;\\"canRequestSettlement\\": boolean;\\"canSeeEpayRequests\\": boolean;\\"canSeeSettlementRequests\\": boolean;\\"canSeeTransactions\\": boolean;\\"canTransferMoney\\": boolean;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"realBalance\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"totalBalance\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"accountNumber\\"?: string;\\"accountTitle\\"?: string;}
+        
+        
+        export enum SubUserPermissionType {Default=\\"Default\\",CanReceiveMoney=\\"CanReceiveMoney\\",CanSeeEpayRequests=\\"CanSeeEpayRequests\\",CanTransferMoney=\\"CanTransferMoney\\",CanSeeTransactions=\\"CanSeeTransactions\\",CanRequestSettlement=\\"CanRequestSettlement\\",CanChargeAccount=\\"CanChargeAccount\\",CanSeeSettlementRequests=\\"CanSeeSettlementRequests\\",CanGroupTransferMoney=\\"CanGroupTransferMoney\\",CanAssistantsCreatesEpayRequest=\\"CanAssistantsCreatesEpayRequest\\"}
+        
+        
+        export interface SubuserInvitationTaskInput {\\"subuserInvitationTaskType\\": SubuserInvitationTaskType;}
+        
+        
+        export enum SubuserInvitationTaskType {Accept=\\"Accept\\",Reject=\\"Reject\\"}
+        
+        
+        export enum SubuserStatus {Connected=\\"Connected\\",DisconnectedByBusinessUser=\\"DisconnectedByBusinessUser\\",DisconnectedBySubUser=\\"DisconnectedBySubUser\\"}
+        
+        
+        export interface TaxiInfoOutput {\\"carTypeCode\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"lineCode\\": number;\\"activityType\\"?: string;\\"destination\\"?: string;\\"source\\"?: string;\\"vehicleColor\\"?: string;\\"vehicleType\\"?: string;}
+        
+        
+        export enum TaxiPaymentProvider {Sepid=\\"Sepid\\",Simorgh=\\"Simorgh\\"}
+        
+        
+        export interface TaxiPriceOutput {
+/**
+ * 
+ * - Format: int64
+ */
+\\"amount\\": number;\\"currency\\"?: string;\\"title\\"?: string;}
+        
+        
+        export interface TaxiRecieptApiDto {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"dateTime\\": string;\\"sepidResponse\\": SepidResponseType;\\"taxiProvider\\": TaxiPaymentProvider;\\"accountName\\"?: string;\\"accountNumber\\"?: string;\\"sepidResponseDisplay\\"?: string;\\"taxiProviderDisplay\\"?: string;}
+        
+        
+        export interface TerminalVersionApiModel {\\"currentVersion\\"?: string;\\"minimumVersion\\"?: string;}
+        
+        
+        export enum TerminalVersionState {Default=\\"Default\\",UpToDate=\\"UpToDate\\",Supported=\\"Supported\\",Deprecated=\\"Deprecated\\"}
+        
+        
+        export interface TotpLoginResult {\\"token\\"?: string;}
+        
+        
+        export interface TransactionApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"accountId\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDateTime\\": string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"remain\\": number;\\"transactionOperationType\\": TransactionOperationType;\\"transactionType\\": TransactionType;
+/**
+ * 
+ * - Format: int64
+ */
+\\"voucherId\\": number;\\"accountNumber\\"?: string;\\"accountTitle\\"?: string;\\"createDate\\"?: string;\\"description\\"?: string;\\"followupId\\"?: string;\\"logicalAction\\"?:  & (LogicalActionType);\\"logicalActionDisplay\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"targetBusinessCategoryId\\"?: number;\\"targetBusinessCategoryName\\"?: string;\\"transactionOperationTypeDisplay\\"?: string;\\"transactionTypeDisplay\\"?: string;\\"voucherType\\"?:  & (VoucherOperationType);\\"voucherTypeDisplay\\"?: string;}
+        
+        
+        export enum TransactionOperationType {Unknown=\\"Unknown\\",Normal=\\"Normal\\",System=\\"System\\",DomainCommission=\\"DomainCommission\\",ResellerCommission=\\"ResellerCommission\\",Block=\\"Block\\",Unblock=\\"Unblock\\",Refund=\\"Refund\\",NoCommissionRemainGift=\\"NoCommissionRemainGift\\",RemainGift=\\"RemainGift\\",DomainBankBatchTransfer=\\"DomainBankBatchTransfer\\",SettlementBatchTransferItem=\\"SettlementBatchTransferItem\\",Synchronization=\\"Synchronization\\",BlockchainWithdrawInternalTransfer=\\"BlockchainWithdrawInternalTransfer\\",BlockchainWithdrawUserWallet=\\"BlockchainWithdrawUserWallet\\",BlockchainIncomingTransaction=\\"BlockchainIncomingTransaction\\",BlockchainWithdrawUserWalletOffchain=\\"BlockchainWithdrawUserWalletOffchain\\",BlockchainFee=\\"BlockchainFee\\"}
+        
+        
+        export enum TransactionType {Debt=\\"Debt\\",Credit=\\"Credit\\"}
+        
+        
+        export interface TransferMoneyApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionAmount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'CommissionAmount' instead]
+ * - Format: decimal
+ * @deprecated Use 'CommissionAmount' instead.
+ */
+\\"domainCommissionAmount\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"payerAccountId\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"targetAccountId\\": number;
+/**
+ * 
+ * [Deprecated, use 'PayerAccountId' instead]
+ * - Format: int64
+ * @deprecated Use 'PayerAccountId' instead.
+ */
+\\"userAccountId\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"voucherId\\": number;\\"description\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'OperationId' instead]
+ * - Format: int64
+ * @deprecated Use 'OperationId' instead.
+ */
+\\"id\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"operationId\\"?: number;\\"payerAccountName\\"?: string;\\"payerAccountNumber\\"?: string;\\"targetAccountNumber\\"?: string;\\"targetUserAvatarUrl\\"?: string;\\"targetUserDisplayName\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'PayerAccountName' instead]
+ * @deprecated Use 'PayerAccountName' instead.
+ */
+\\"userAccountName\\"?: string;}
+        
+        
+        export interface TransferMoneyInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"targetUserAccountId\\": number;\\"description\\"?: string;\\"targetIdentifier\\"?: string;}
+        
+        
+        export interface UnreadNotificationCountApiModel {\\"channel\\": NotificationChannel;
+/**
+ * 
+ * - Format: int32
+ */
+\\"unreadCount\\": number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;}
+        
+        
+        export interface UpgradeToBusinessApiModel {\\"businessShareType\\": BusinessShareType;\\"businessType\\": BusinessType;\\"status\\": IdentityStatus;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"upgradeToBusinessRequestStatus\\":  & (IdentityStatus);
+/**
+ * 
+ * [Deprecated, use 'BusinessShareType' instead]
+ * @deprecated Use 'BusinessShareType' instead.
+ */
+\\"userIdentityType\\":  & (BusinessShareType);\\"address\\"?: string;\\"businessLogoImageLink\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"businessLogoImageUniqueId\\"?: string;\\"businessName\\"?: string;\\"businessShareTypeDisplay\\"?: string;\\"businessTypeDisplay\\"?: string;\\"city\\"?: string;\\"description\\"?: string;\\"documents\\"?: DocumentApiModel[];\\"email\\"?: string;\\"faxNumber\\"?: string;\\"managerName\\"?: string;\\"managerPhoneNumber\\"?: string;\\"organizationName\\"?: string;\\"organizationNationalCode\\"?: string;\\"personNationalCode\\"?: string;\\"phoneNumber\\"?: string;\\"rejectCause\\"?:  & (UpgradeToBusinessRejectCause);\\"rejectCauseDescription\\"?: string;\\"rejectCauseDisplay\\"?: string;\\"state\\"?: string;\\"statusDisplay\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'RejectCauseDescription' instead]
+ * @deprecated Use 'RejectCauseDescription' instead.
+ */
+\\"upgradeToBusinessRequestStatusDescription\\"?: string;\\"webSiteUrl\\"?: string;}
+        
+        
+        export enum UpgradeToBusinessRejectCause {DocumentsLack=\\"DocumentsLack\\",DocumentsMismatch=\\"DocumentsMismatch\\",Other=\\"Other\\"}
+        
+        
+        export interface UpgradeToBusinessUserInput {\\"address\\"?: string;\\"businessName\\"?: string;\\"businessShareType\\"?:  & (BusinessShareType);\\"businessType\\"?:  & (BusinessType);\\"city\\"?: string;\\"documents\\"?: DocumentInput[];\\"email\\"?: string;\\"faxNumber\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"logoFileUniqueId\\"?: string;\\"managerName\\"?: string;\\"managerPhoneNumber\\"?: string;\\"organizationName\\"?: string;\\"organizationNationalCode\\"?: string;\\"phoneNumber\\"?: string;\\"state\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'BusinessShareType' instead]
+ * @deprecated Use 'BusinessShareType' instead.
+ */
+\\"userIdentityType\\"?:  & (BusinessShareType);\\"webSiteUrl\\"?: string;}
+        
+        
+        export interface UserBankApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"bankId\\": number;\\"businessShareType\\": BusinessShareType;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;
+/**
+ * 
+ * [Deprecated, use 'BusinessShareType' instead]
+ * @deprecated Use 'BusinessShareType' instead.
+ */
+\\"identityType\\":  & (BusinessShareType);\\"isVisible\\": boolean;\\"status\\": IdentityStatus;\\"accountNumber\\"?: string;\\"bankLogo\\"?: string;\\"bankName\\"?: string;\\"businessShareTypeDisplay\\"?: string;\\"firstName\\"?: string;\\"lastName\\"?: string;\\"name\\"?: string;\\"rejectCause\\"?:  & (UserBankRejectCause);\\"rejectCauseDescription\\"?: string;\\"rejectCauseDisplay\\"?: string;\\"shebaNo\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'RejectCauseDescription' instead]
+ * @deprecated Use 'RejectCauseDescription' instead.
+ */
+\\"statusDescription\\"?: string;\\"statusDisplay\\"?: string;}
+        
+        
+        export interface UserBankChangeVisibilityInput {\\"isVisible\\"?: boolean;}
+        
+        
+        export type UserBankDetailApiModel =  & (UserBankApiModel & {\\"documents\\"?: DocumentApiModel[];\\"nationalCode\\"?: string;})
+        
+        
+        export interface UserBankInput {\\"accountNumber\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"bankId\\"?: number;\\"businessShareType\\"?:  & (BusinessShareType);\\"documents\\"?: DocumentInput[];\\"firstName\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'BusinessShareType' instead]
+ * @deprecated Use 'BusinessShareType' instead.
+ */
+\\"identityType\\"?:  & (BusinessShareType);\\"isVisible\\"?: boolean;\\"lastName\\"?: string;\\"name\\"?: string;\\"nationalCode\\"?: string;\\"shebaNo\\"?: string;}
+        
+        
+        export enum UserBankRejectCause {DocumentsLack=\\"DocumentsLack\\",DocumentsMismatch=\\"DocumentsMismatch\\",Etc=\\"Etc\\"}
+        
+        
+        export interface UserChangePasswordInput {\\"currentPassword\\"?: string;\\"newPassword\\"?: string;}
+        
+        
+        export type UserDetailQuery =  & (UserMeQuery & {\\"address\\"?: string;\\"city\\"?: string;\\"email\\"?: string;\\"introducedBySubDomain\\"?: string;\\"nationalCode\\"?: string;\\"phoneNumber\\"?: string;\\"state\\"?: string;})
+        
+        
+        export interface UserForgetPasswordInput {\\"phoneNumber\\"?: string;}
+        
+        
+        export enum UserIdentifierType {Default=\\"Default\\",PhoneNumber=\\"PhoneNumber\\",Email=\\"Email\\",CustomerNumber=\\"CustomerNumber\\",AccountNumber=\\"AccountNumber\\"}
+        
+        
+        export enum UserIdentityRejectCause {DocumentsLack=\\"DocumentsLack\\",DocumentsMismatch=\\"DocumentsMismatch\\",DocumentsRejected=\\"DocumentsRejected\\",Etc=\\"Etc\\"}
+        
+        
+        export interface UserIdentityRequestQuery {\\"status\\": IdentityStatus;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"userIdentityRequestStatus\\":  & (IdentityStatus);\\"documents\\"?: DocumentApiModel[];\\"firstName\\"?: string;\\"lastName\\"?: string;\\"nationalCode\\"?: string;\\"rejectCause\\"?:  & (UserIdentityRejectCause);\\"rejectCauseDescription\\"?: string;\\"rejectCauseDisplay\\"?: string;\\"statusDisplay\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'RejectCauseDescription' instead]
+ * @deprecated Use 'RejectCauseDescription' instead.
+ */
+\\"userIdentityRequestStatusDescription\\"?: string;}
+        
+        
+        export interface UserMeQuery {\\"identityStatus\\": IdentityStatus;\\"isBusinessUser\\": boolean;\\"isResellerUser\\": boolean;\\"isSubUser\\": boolean;
+/**
+ * 
+ * - Format: int64
+ */
+\\"shareCode\\": number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"birthDate\\"?: string;\\"birthDateDisplay\\"?: string;\\"businessName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"businessUserId\\"?: string;\\"gender\\"?:  & (Gender);\\"genderDisplay\\"?: string;\\"identityStatusDisplay\\"?: string;\\"profileImageLink\\"?: string;\\"referredBy\\"?: string;\\"title\\"?: string;}
+        
+        
+        export interface UserMinimalDto {
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"displayName\\"?: string;\\"positionTitle\\"?: string;}
+        
+        
+        export interface UserPluginApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"isActive\\": boolean;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"pluginConfig\\"?: string;\\"pluginName\\"?: string;\\"userDisplayName\\"?: string;}
+        
+        
+        export interface UserPluginDetailApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"isActive\\": boolean;
+/**
+ * 
+ * - Format: int32
+ */
+\\"pluginId\\": number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"pluginAmountCalculationExpression\\"?: string;\\"pluginConfig\\"?: string;\\"pluginLogoFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"pluginLogoFileUniqueId\\"?: string;\\"pluginLogoFileUrl\\"?: string;\\"pluginName\\"?: string;\\"properties\\"?: PluginPropertyApiModel[];\\"userDisplayName\\"?: string;}
+        
+        
+        export interface UserPluginTogggleApiModel {\\"isActive\\": boolean;}
+        
+        
+        export interface UserProfileAvatarInput {
+/**
+ * 
+ * - Format: guid
+ */
+\\"fileUniqueId\\"?: string;}
+        
+        
+        export interface UserProfileInput {\\"address\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"birthDate\\"?: string;\\"city\\"?: string;\\"email\\"?: string;\\"gender\\"?:  & (Gender);\\"state\\"?: string;}
+        
+        
+        export enum UserStatus {None=\\"None\\",NotVerified=\\"NotVerified\\",VerifiedButNotCompleted=\\"VerifiedButNotCompleted\\",Active=\\"Active\\",TemporaryBlocked=\\"TemporaryBlocked\\",AutoPasswordGenerated=\\"AutoPasswordGenerated\\"}
+        
+        
+        export interface UserVerifyForgetPasswordInput {\\"newPassword\\"?: string;\\"phoneNumber\\"?: string;\\"token\\"?: string;\\"verifyCode\\"?: string;}
+        
+        
+        export interface UserWorkspaceQuery {
+/**
+ * 
+ * - Format: guid
+ */
+\\"businessUserId\\": string;\\"workspaceType\\": WorkspaceType;\\"businessAvatarUrl\\"?: string;\\"businessName\\"?: string;\\"positionTitle\\"?: string;}
+        
+        
+        export interface VerifyPhoneNumberInput {
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"subDomainId\\"?: string;\\"token\\"?: string;\\"verifyCode\\"?: string;}
+        
+        
+        export enum VoucherOperationType {Unknown=\\"Unknown\\",EPayViaBankWithCommissionByPayer=\\"EPayViaBankWithCommissionByPayer\\",EPayViaBankWithCommissionByUser=\\"EPayViaBankWithCommissionByUser\\",EPayViaPSPWithCommissionByPayer=\\"EPayViaPSPWithCommissionByPayer\\",EPayViaPSPWithCommissionByUser=\\"EPayViaPSPWithCommissionByUser\\",EPayViaWalletWithCommissionByPayer=\\"EPayViaWalletWithCommissionByPayer\\",EPayViaWalletWithCommissionByUser=\\"EPayViaWalletWithCommissionByUser\\",TransferMoney=\\"TransferMoney\\",ChargeWallet=\\"ChargeWallet\\",ServiceBill=\\"ServiceBill\\",ServiceMobileCharge=\\"ServiceMobileCharge\\",POSViaBank=\\"POSViaBank\\",POSViaWallet=\\"POSViaWallet\\",ShareAndBlockRequest=\\"ShareAndBlockRequest\\",ShareRequest=\\"ShareRequest\\",SettlementAuto=\\"SettlementAuto\\",SettlementManual=\\"SettlementManual\\",SettlementSuspected=\\"SettlementSuspected\\",GroupTransferMoney=\\"GroupTransferMoney\\",ShareAndUnblock=\\"ShareAndUnblock\\",RefundWithSystemPayer=\\"RefundWithSystemPayer\\",RefundWithAnonymousPayer=\\"RefundWithAnonymousPayer\\",PayCommand=\\"PayCommand\\",GiftForReferrer=\\"GiftForReferrer\\",GiftForNoCommissionRemain=\\"GiftForNoCommissionRemain\\",Sepid=\\"Sepid\\",BatchTransferItem=\\"BatchTransferItem\\",AbstractProviderSynchronization=\\"AbstractProviderSynchronization\\",BlockchainWithdrawInternalTransfer=\\"BlockchainWithdrawInternalTransfer\\",BlockchainWithdrawUserWallet=\\"BlockchainWithdrawUserWallet\\",BlockchainIncomingTransaction=\\"BlockchainIncomingTransaction\\",BlockchainWithdrawUserWalletOnChain=\\"BlockchainWithdrawUserWalletOnChain\\"}
+        
+        
+        export type WalletDetailApiModel =  & (WalletDisplayApiModel & {\\"notificationEnabled\\": boolean;
+/**
+ * 
+ * - Format: int32
+ */
+\\"permittedSubuserCount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"posPaidCount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"posScanCount\\": number;\\"accountQrCodeUrl\\"?: string;\\"actionPolicies\\"?: CommissionPolicyApiModel[];\\"posLinkUrl\\"?: string;})
+        
+        
+        export interface WalletDisplayApiModel {\\"automaticSettlement\\": boolean;\\"getComissionFromPayer\\": boolean;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"isActive\\": boolean;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"realBalance\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"totalBalance\\": number;\\"directUserBankAccountNumber\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"directUserBankBankId\\"?: number;\\"directUserBankBankName\\"?: string;\\"directUserBankShebaNumber\\"?: string;\\"intermediateUserBankAccountNumber\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"intermediateUserBankBankId\\"?: number;\\"intermediateUserBankBankName\\"?: string;\\"intermediateUserBankShebaNumber\\"?: string;\\"number\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"relatedUserAccountIndex\\"?: number;\\"title\\"?: string;}
+        
+        
+        export interface WalletReceiptApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionAmount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDate\\": string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"payerAccountId\\": number;\\"callbackUrl\\"?: string;\\"creatorUserAvatarUrl\\"?: string;\\"creatorUserDisplayName\\"?: string;\\"description\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"operationId\\"?: number;\\"payerAccountName\\"?: string;\\"payerAccountNumber\\"?: string;\\"sharerUrl\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"targetAccountId\\"?: number;\\"targetAccountNumber\\"?: string;\\"targetUserAvatarUrl\\"?: string;\\"targetUserDisplayName\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"voucherId\\"?: number;}
+        
+        
+        export enum WorkspaceType {User=\\"User\\",SubUser=\\"SubUser\\"}
+        "
+`;
+
+exports[`only includes methods ends with Id generate Code 1`] = `
+"
+//@ts-nocheck
+/**
+* AUTO_GENERATED Do not change this file directly, use config.ts file instead
+*
+* @version 6
+*/
+
+import type { AxiosRequestConfig } from \\"axios\\";
+import type { SwaggerResponse } from \\"./config\\";
+import { Http } from \\"./httpRequest\\";
+//@ts-ignore
+import qs from \\"qs\\";
+import type { SubUserConnectionApiModel, EditConnectionInfoInput, EditSubUserPermissionInput, EpayRequestDetailApiModel, WalletReceiptApiModel, EpayRequestPayInput, PluginApiModel, BankReceiptApiModel, BusinessUserConnectionApiModel, SubUserAccountDetailQuery, TransactionApiModel, TransferMoneyApiModel, UserBankApiModel, UserBankDetailApiModel, WalletDisplayApiModel, WalletDetailApiModel, RequestBodyTransferMoneyInput, RequestBodyNewEpayRequestInput, RequestBodySubUserNotificationStatusInput, RequestBodyUserBankInput, RequestBodyAccountCreationApiModel,}  from \\"./types\\"
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const __DEV__ = process.env.NODE_ENV !== \\"production\\";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function overrideConfig(
+  config?: AxiosRequestConfig,
+  configOverride?: AxiosRequestConfig,
+): AxiosRequestConfig {
+  return {
+    ...config,
+    ...configOverride,
+    headers: {
+      ...config?.headers,
+      ...configOverride?.headers,
+    },
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function template(path: string, obj: { [x: string]: any } = {}) {
+    Object.keys(obj).forEach((key) => {
+      const re = new RegExp(\`{\${key}}\`, \\"i\\");
+      path = path.replace(re, obj[key]);
+    });
+
+    return path;
+}
+
+function isFormData(obj: any) {
+  // This checks for the append method which should exist on FormData instances
+  return (
+    (typeof obj === \\"object\\" &&
+      typeof obj.append === \\"function\\" &&
+      obj[Symbol.toStringTag] === undefined) ||
+    obj[Symbol.toStringTag] === \\"FormData\\"
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function objToForm(requestBody: object) {
+  if (isFormData(requestBody)) {
+    return requestBody;
+  }
+  const formData = new FormData();
+
+  Object.entries(requestBody).forEach(([key, value]) => {
+    value && formData.append(key, value);
+  });
+
+  return formData;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function objToUrlencoded(requestBody: object) {
+  return qs.stringify(requestBody)
+}
+
+
+/**
+ * 
+ * Disconnect sub user connection
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const deleteBusinessUserConnectionConnectionId = (
+    
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubUserConnectionApiModel)>> => {
+  
+  return Http.deleteRequest(
+    template(deleteBusinessUserConnectionConnectionId.key,{connectionId,}),
+    undefined,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+deleteBusinessUserConnectionConnectionId.key = \\"/BusinessUser/connection/{connectionId}\\";
+
+export const deleteBusinessUserConnectionConnectionIdPermissionUserWalletId = (
+    connectionId: number,
+/**
+ * 
+ * Id of Account to delete it's permissios
+ */
+userWalletId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.deleteRequest(
+    template(deleteBusinessUserConnectionConnectionIdPermissionUserWalletId.key,{connectionId,userWalletId,}),
+    undefined,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT5,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+deleteBusinessUserConnectionConnectionIdPermissionUserWalletId.key = \\"/BusinessUser/connection/{connectionId}/permission/{userWalletId}\\";
+
+
+/**
+ * 
+ * Disconnect business user connection
+[Feature just allowed for SubUsers]
+[Needs secure login]
+[Deprecated, use 'user/connection/{connectionId}' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const deleteSubUserConnectionConnectionId = (
+    
+/**
+ * 
+ * connection id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (BusinessUserConnectionApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"deleteSubUserConnectionConnectionId\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.deleteRequest(
+    template(deleteSubUserConnectionConnectionId.key,{connectionId,}),
+    undefined,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+deleteSubUserConnectionConnectionId.key = \\"/SubUser/connection/{connectionId}\\";
+
+
+/**
+ * 
+ * Disconnect business user connection
+[Feature just allowed for normal users]
+[Needs secure login]
+ */
+export const deleteUserConnectionConnectionId = (
+    
+/**
+ * 
+ * connection id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (BusinessUserConnectionApiModel)>> => {
+  
+  return Http.deleteRequest(
+    template(deleteUserConnectionConnectionId.key,{connectionId,}),
+    undefined,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+deleteUserConnectionConnectionId.key = \\"/User/connection/{connectionId}\\";
+
+
+/**
+ * 
+ * Get the connection detail
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const getBusinessUserConnectionConnectionId = (
+    
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubUserConnectionApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getBusinessUserConnectionConnectionId.key,{connectionId,}),
+    undefined,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getBusinessUserConnectionConnectionId.key = \\"/BusinessUser/connection/{connectionId}\\";
+
+
+/**
+ * 
+ * Get epay request detail based on Id
+ */
+export const getEpayRequestEpayId = (
+    
+/**
+ * 
+ * EpayRequest's Id
+ */
+epayId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (EpayRequestDetailApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getEpayRequestEpayId.key,{epayId,}),
+    undefined,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getEpayRequestEpayId.key = \\"/EpayRequest/{epayId}\\";
+
+export const getPluginPluginId = (
+    pluginId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (PluginApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getPluginPluginId.key,{pluginId,}),
+    undefined,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getPluginPluginId.key = \\"/Plugin/{pluginId}\\";
+
+
+/**
+ * 
+ * Get bank receipt by EPayTry id
+[For anonymous users]
+ */
+export const getReceiptBankEpayTryId = (
+    
+/**
+ * 
+ * EpayTry's id to get receipt for
+ */
+epayTryId: string,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (BankReceiptApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getReceiptBankEpayTryId.key,{epayTryId,}),
+    undefined,
+    undefined,
+    undefined,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getReceiptBankEpayTryId.key = \\"/Receipt/bank/{epayTryId}\\";
+
+
+/**
+ * 
+ * Get permission details of an Account
+[Feature just allowed for SubUsers]
+ */
+export const getSubUserAccountUserWalletId = (
+    userWalletId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubUserAccountDetailQuery)>> => {
+  
+  return Http.getRequest(
+    template(getSubUserAccountUserWalletId.key,{userWalletId,}),
+    undefined,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getSubUserAccountUserWalletId.key = \\"/SubUser/account/{userWalletId}\\";
+
+
+/**
+ * 
+ * Get a Transaction by it's Id
+[Needs secure login]
+ */
+export const getTransactionTransactionId = (
+    transactionId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (TransactionApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getTransactionTransactionId.key,{transactionId,}),
+    undefined,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getTransactionTransactionId.key = \\"/Transaction/{transactionId}\\";
+
+
+/**
+ * 
+ * get user bank detail
+[Needs secure login]
+ */
+export const getUserBankUserBankId = (
+    
+/**
+ * 
+ * User bank id
+ */
+userBankId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (UserBankDetailApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getUserBankUserBankId.key,{userBankId,}),
+    undefined,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserBankUserBankId.key = \\"/UserBank/{userBankId}\\";
+
+export const getUserWalletUserWalletId = (
+    userWalletId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (WalletDetailApiModel)>> => {
+  
+  return Http.getRequest(
+    template(getUserWalletUserWalletId.key,{userWalletId,}),
+    undefined,
+    undefined,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+getUserWalletUserWalletId.key = \\"/UserWallet/{userWalletId}\\";
+
+
+/**
+ * 
+ * Resend Connection Request to Sub-User
+[Feature just allowed for the business users]
+[Deprecated, use 'businessuser/invite/{invitationId}/resend' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const postBusinessUserResendInvitationId = (
+    
+/**
+ * 
+ * Invitation Id
+ */
+invitationId: number,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubUserConnectionApiModel)>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"postBusinessUserResendInvitationId\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.postRequest(
+    template(postBusinessUserResendInvitationId.key,{invitationId,}),
+    undefined,
+    undefined,
+    _CONSTANT1,
+    overrideConfig(_CONSTANT0,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+postBusinessUserResendInvitationId.key = \\"/BusinessUser/resend/{invitationId}\\";
+
+export const postEpayRequestEpayTokenPayUserWalletId = (
+    epayToken: string,userWalletId: number,requestBody: EpayRequestPayInput,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (WalletReceiptApiModel)>> => {
+  
+  return Http.postRequest(
+    template(postEpayRequestEpayTokenPayUserWalletId.key,{epayToken,userWalletId,}),
+    undefined,
+    requestBody,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+postEpayRequestEpayTokenPayUserWalletId.key = \\"/EpayRequest/{epayToken}/pay/{userWalletId}\\";
+
+export const postEpayRequestUserWalletId = (
+    
+/**
+ * 
+ * User Wallet id
+ */
+userWalletId: number,requestBody: RequestBodyNewEpayRequestInput,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (EpayRequestDetailApiModel)>> => {
+  
+  return Http.postRequest(
+    template(postEpayRequestUserWalletId.key,{userWalletId,}),
+    undefined,
+    requestBody,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+postEpayRequestUserWalletId.key = \\"/EpayRequest/{userWalletId}\\";
+
+
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const postSubUserNotificationUserWalletId = (
+    
+/**
+ * 
+ * UserWallet's Id
+ */
+userWalletId: number,requestBody: RequestBodySubUserNotificationStatusInput,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  if (__DEV__) {
+    console.warn(
+      \\"postSubUserNotificationUserWalletId\\",
+      \\"This endpoint deprecated and will be remove. Please use an alternative\\",
+    );
+  }
+  return Http.postRequest(
+    template(postSubUserNotificationUserWalletId.key,{userWalletId,}),
+    undefined,
+    requestBody,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT4,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+postSubUserNotificationUserWalletId.key = \\"/SubUser/notification/{userWalletId}\\";
+
+
+/**
+ * 
+ * Transfer money
+ */
+export const postTransferUserWalletId = (
+    userWalletId: number,requestBody: RequestBodyTransferMoneyInput,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (TransferMoneyApiModel)>> => {
+  
+  return Http.postRequest(
+    template(postTransferUserWalletId.key,{userWalletId,}),
+    undefined,
+    requestBody,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+postTransferUserWalletId.key = \\"/Transfer/{userWalletId}\\";
+
+
+/**
+ * 
+ * Change sub user connection info
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const putBusinessUserConnectionConnectionId = (
+    
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,requestBody: EditConnectionInfoInput,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (SubUserConnectionApiModel)>> => {
+  
+  return Http.putRequest(
+    template(putBusinessUserConnectionConnectionId.key,{connectionId,}),
+    undefined,
+    requestBody,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+putBusinessUserConnectionConnectionId.key = \\"/BusinessUser/connection/{connectionId}\\";
+
+export const putBusinessUserConnectionConnectionIdPermissionUserWalletId = (
+    connectionId: number,
+/**
+ * 
+ * Id of Account to edit it's permissios
+ */
+userWalletId: number,requestBody: EditSubUserPermissionInput,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse<string>> => {
+  
+  return Http.putRequest(
+    template(putBusinessUserConnectionConnectionIdPermissionUserWalletId.key,{connectionId,userWalletId,}),
+    undefined,
+    requestBody,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT4,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+putBusinessUserConnectionConnectionIdPermissionUserWalletId.key = \\"/BusinessUser/connection/{connectionId}/permission/{userWalletId}\\";
+
+
+/**
+ * 
+ * Edit user bank
+[Needs secure login]
+ */
+export const putUserBankUserBankId = (
+    
+/**
+ * 
+ * User bank id
+ */
+userBankId: number,requestBody: RequestBodyUserBankInput,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (UserBankApiModel)>> => {
+  
+  return Http.putRequest(
+    template(putUserBankUserBankId.key,{userBankId,}),
+    undefined,
+    requestBody,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+putUserBankUserBankId.key = \\"/UserBank/{userBankId}\\";
+
+export const putUserWalletUserWalletId = (
+    userWalletId: number,requestBody: RequestBodyAccountCreationApiModel,configOverride?:AxiosRequestConfig
+): Promise<SwaggerResponse< & (WalletDisplayApiModel)>> => {
+  
+  return Http.putRequest(
+    template(putUserWalletUserWalletId.key,{userWalletId,}),
+    undefined,
+    requestBody,
+    _CONSTANT2,
+    overrideConfig(_CONSTANT3,
+      configOverride,
+    )
+  )
+}
+
+/** Key is end point string without base url */
+putUserWalletUserWalletId.key = \\"/UserWallet/{userWalletId}\\";
+export const _CONSTANT0 = {
+              headers: {
+                \\"Content-Type\\": \\"application/json\\",
+                Accept: \\"application/json\\",
+              },
+            };export const _CONSTANT1 = [{\\"bearer\\":[\\"Business\\"]}];export const _CONSTANT2 = [{\\"bearer\\":[]}];export const _CONSTANT3 = {
+              headers: {
+                \\"Content-Type\\": \\"application/json-patch+json\\",
+                Accept: \\"application/json\\",
+              },
+            };export const _CONSTANT4 = {
+              headers: {
+                \\"Content-Type\\": \\"application/json-patch+json\\",
+                Accept: \\"*/*\\",
+              },
+            };export const _CONSTANT5 = {
+              headers: {
+                \\"Content-Type\\": \\"application/json\\",
+                Accept: \\"*/*\\",
+              },
+            };"
+`;
+
+exports[`only includes methods ends with Id generate hooks 1`] = `
+"
+//@ts-nocheck
+/**
+* AUTO_GENERATED Do not change this file directly, use config.ts file instead
+*
+* @version 6
+*/
+
+
+import { AxiosRequestConfig } from \\"axios\\";
+import {
+  UseQueryOptions,
+  useQuery,
+  useMutation,
+  UseMutationOptions,
+  
+  QueryClient,
+  QueryKey,
+} from \\"@tanstack/react-query\\";
+import { RequestError, SwaggerResponse } from \\"./config\\";
+
+import type { BankReceiptApiModel, BusinessUserConnectionApiModel, EditConnectionInfoInput, EditSubUserPermissionInput, EpayRequestDetailApiModel, EpayRequestPayInput, PluginApiModel, RequestBodyAccountCreationApiModel, RequestBodyNewEpayRequestInput, RequestBodySubUserNotificationStatusInput, RequestBodyTransferMoneyInput, RequestBodyUserBankInput, SubUserAccountDetailQuery, SubUserConnectionApiModel, TransactionApiModel, TransferMoneyApiModel, UserBankApiModel, UserBankDetailApiModel, WalletDetailApiModel, WalletDisplayApiModel, WalletReceiptApiModel,}  from \\"./types\\"
+import { deleteBusinessUserConnectionConnectionId, deleteBusinessUserConnectionConnectionIdPermissionUserWalletId, deleteSubUserConnectionConnectionId, deleteUserConnectionConnectionId, getBusinessUserConnectionConnectionId, getEpayRequestEpayId, getPluginPluginId, getReceiptBankEpayTryId, getSubUserAccountUserWalletId, getTransactionTransactionId, getUserBankUserBankId, getUserWalletUserWalletId, postBusinessUserResendInvitationId, postEpayRequestEpayTokenPayUserWalletId, postEpayRequestUserWalletId, postSubUserNotificationUserWalletId, postTransferUserWalletId, putBusinessUserConnectionConnectionId, putBusinessUserConnectionConnectionIdPermissionUserWalletId, putUserBankUserBankId, putUserWalletUserWalletId,}  from \\"./services\\"
+
+    export type SwaggerTypescriptMutationDefaultParams<TExtra> = {_extraVariables?:TExtra, configOverride?:AxiosRequestConfig}
+    type SwaggerTypescriptUseQueryOptions<TData> = Omit<UseQueryOptions<SwaggerResponse<TData>,RequestError | Error>,\\"queryKey\\">;
+
+    type SwaggerTypescriptUseMutationOptions<TData, TRequest, TExtra> = UseMutationOptions<
+      SwaggerResponse<TData>,
+      RequestError | Error,
+      TRequest & SwaggerTypescriptMutationDefaultParams<TExtra>
+    >;
+
+    type SwaggerTypescriptUseMutationOptionsVoid<
+      TData,
+      TExtra
+    > = UseMutationOptions<
+      SwaggerResponse<TData>,
+      RequestError | Error,
+      SwaggerTypescriptMutationDefaultParams<TExtra> | void
+    >;  
+    
+      
+/**
+ * 
+ * Disconnect sub user connection
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const useDeleteBusinessUserConnectionConnectionId =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (SubUserConnectionApiModel), {
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { connectionId,
+          
+          
+           configOverride } = _o || {};
+
+            return deleteBusinessUserConnectionConnectionId(
+                 connectionId,
+          
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      export const useDeleteBusinessUserConnectionConnectionIdPermissionUserWalletId =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions<string, {connectionId: number,
+/**
+ * 
+ * Id of Account to delete it's permissios
+ */
+userWalletId: number,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { connectionId,userWalletId,
+          
+          
+           configOverride } = _o || {};
+
+            return deleteBusinessUserConnectionConnectionIdPermissionUserWalletId(
+                 connectionId,userWalletId,
+          
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      
+/**
+ * 
+ * Disconnect business user connection
+[Feature just allowed for SubUsers]
+[Needs secure login]
+[Deprecated, use 'user/connection/{connectionId}' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const useDeleteSubUserConnectionConnectionId =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (BusinessUserConnectionApiModel), {
+/**
+ * 
+ * connection id
+ */
+connectionId: number,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { connectionId,
+          
+          
+           configOverride } = _o || {};
+
+            return deleteSubUserConnectionConnectionId(
+                 connectionId,
+          
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      
+/**
+ * 
+ * Disconnect business user connection
+[Feature just allowed for normal users]
+[Needs secure login]
+ */
+export const useDeleteUserConnectionConnectionId =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (BusinessUserConnectionApiModel), {
+/**
+ * 
+ * connection id
+ */
+connectionId: number,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { connectionId,
+          
+          
+           configOverride } = _o || {};
+
+            return deleteUserConnectionConnectionId(
+                 connectionId,
+          
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      
+/**
+ * 
+ * Get the connection detail
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const useGetBusinessUserConnectionConnectionId = (
+           
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,options?:SwaggerTypescriptUseQueryOptions< & (SubUserConnectionApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetBusinessUserConnectionConnectionId.info( connectionId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetBusinessUserConnectionConnectionId.info = (
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getBusinessUserConnectionConnectionId.key,connectionId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getBusinessUserConnectionConnectionId(
+                   connectionId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetBusinessUserConnectionConnectionId.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,options?:SwaggerTypescriptUseQueryOptions< & (SubUserConnectionApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetBusinessUserConnectionConnectionId.info( connectionId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get epay request detail based on Id
+ */
+export const useGetEpayRequestEpayId = (
+           
+/**
+ * 
+ * EpayRequest's Id
+ */
+epayId: number,options?:SwaggerTypescriptUseQueryOptions< & (EpayRequestDetailApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetEpayRequestEpayId.info( epayId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetEpayRequestEpayId.info = (
+/**
+ * 
+ * EpayRequest's Id
+ */
+epayId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getEpayRequestEpayId.key,epayId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getEpayRequestEpayId(
+                   epayId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetEpayRequestEpayId.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * EpayRequest's Id
+ */
+epayId: number,options?:SwaggerTypescriptUseQueryOptions< & (EpayRequestDetailApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetEpayRequestEpayId.info( epayId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetPluginPluginId = (
+           pluginId: number,options?:SwaggerTypescriptUseQueryOptions< & (PluginApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetPluginPluginId.info( pluginId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetPluginPluginId.info = (pluginId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getPluginPluginId.key,pluginId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getPluginPluginId(
+                   pluginId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetPluginPluginId.prefetch = (
+            client: QueryClient,
+            pluginId: number,options?:SwaggerTypescriptUseQueryOptions< & (PluginApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetPluginPluginId.info( pluginId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get bank receipt by EPayTry id
+[For anonymous users]
+ */
+export const useGetReceiptBankEpayTryId = (
+           
+/**
+ * 
+ * EpayTry's id to get receipt for
+ */
+epayTryId: string,options?:SwaggerTypescriptUseQueryOptions< & (BankReceiptApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetReceiptBankEpayTryId.info( epayTryId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetReceiptBankEpayTryId.info = (
+/**
+ * 
+ * EpayTry's id to get receipt for
+ */
+epayTryId: string,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getReceiptBankEpayTryId.key,epayTryId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getReceiptBankEpayTryId(
+                   epayTryId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetReceiptBankEpayTryId.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * EpayTry's id to get receipt for
+ */
+epayTryId: string,options?:SwaggerTypescriptUseQueryOptions< & (BankReceiptApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetReceiptBankEpayTryId.info( epayTryId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get permission details of an Account
+[Feature just allowed for SubUsers]
+ */
+export const useGetSubUserAccountUserWalletId = (
+           userWalletId: number,options?:SwaggerTypescriptUseQueryOptions< & (SubUserAccountDetailQuery)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetSubUserAccountUserWalletId.info( userWalletId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetSubUserAccountUserWalletId.info = (userWalletId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getSubUserAccountUserWalletId.key,userWalletId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getSubUserAccountUserWalletId(
+                   userWalletId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetSubUserAccountUserWalletId.prefetch = (
+            client: QueryClient,
+            userWalletId: number,options?:SwaggerTypescriptUseQueryOptions< & (SubUserAccountDetailQuery)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetSubUserAccountUserWalletId.info( userWalletId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Get a Transaction by it's Id
+[Needs secure login]
+ */
+export const useGetTransactionTransactionId = (
+           transactionId: number,options?:SwaggerTypescriptUseQueryOptions< & (TransactionApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetTransactionTransactionId.info( transactionId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetTransactionTransactionId.info = (transactionId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getTransactionTransactionId.key,transactionId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getTransactionTransactionId(
+                   transactionId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetTransactionTransactionId.prefetch = (
+            client: QueryClient,
+            transactionId: number,options?:SwaggerTypescriptUseQueryOptions< & (TransactionApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetTransactionTransactionId.info( transactionId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * get user bank detail
+[Needs secure login]
+ */
+export const useGetUserBankUserBankId = (
+           
+/**
+ * 
+ * User bank id
+ */
+userBankId: number,options?:SwaggerTypescriptUseQueryOptions< & (UserBankDetailApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserBankUserBankId.info( userBankId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserBankUserBankId.info = (
+/**
+ * 
+ * User bank id
+ */
+userBankId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserBankUserBankId.key,userBankId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserBankUserBankId(
+                   userBankId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserBankUserBankId.prefetch = (
+            client: QueryClient,
+            
+/**
+ * 
+ * User bank id
+ */
+userBankId: number,options?:SwaggerTypescriptUseQueryOptions< & (UserBankDetailApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserBankUserBankId.info( userBankId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      export const useGetUserWalletUserWalletId = (
+           userWalletId: number,options?:SwaggerTypescriptUseQueryOptions< & (WalletDetailApiModel)>,configOverride?:AxiosRequestConfig
+           ) => {
+          const { key, fun } = useGetUserWalletUserWalletId.info( userWalletId,
+          
+          
+           configOverride);
+          return useQuery(
+               {
+                queryKey: key, 
+                queryFn:fun,
+                ...options
+              }
+               )  
+          }
+        useGetUserWalletUserWalletId.info = (userWalletId: number,configOverride?:AxiosRequestConfig) => {
+              return {
+                key: [getUserWalletUserWalletId.key,userWalletId,
+            
+            
+            ] as QueryKey,
+                fun: () =>
+                getUserWalletUserWalletId(
+                   userWalletId,
+          
+          
+          
+                  configOverride
+                ),
+              };
+            };useGetUserWalletUserWalletId.prefetch = (
+            client: QueryClient,
+            userWalletId: number,options?:SwaggerTypescriptUseQueryOptions< & (WalletDetailApiModel)>,configOverride?:AxiosRequestConfig) => {
+                const { key, fun } = useGetUserWalletUserWalletId.info( userWalletId,
+          
+          
+           configOverride);
+
+                return client.getQueryData(key)
+                ? Promise.resolve()
+                : client.prefetchQuery(
+                {
+                  queryKey:key,
+                  queryFn:()=>fun(),
+                  ...options
+                }
+                  );
+              }
+      
+/**
+ * 
+ * Resend Connection Request to Sub-User
+[Feature just allowed for the business users]
+[Deprecated, use 'businessuser/invite/{invitationId}/resend' instead]
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const usePostBusinessUserResendInvitationId =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (SubUserConnectionApiModel), {
+/**
+ * 
+ * Invitation Id
+ */
+invitationId: number,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { invitationId,
+          
+          
+           configOverride } = _o || {};
+
+            return postBusinessUserResendInvitationId(
+                 invitationId,
+          
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      export const usePostEpayRequestEpayTokenPayUserWalletId =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (WalletReceiptApiModel), {epayToken: string,userWalletId: number,requestBody: EpayRequestPayInput,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { epayToken,userWalletId,
+          requestBody,
+          
+           configOverride } = _o || {};
+
+            return postEpayRequestEpayTokenPayUserWalletId(
+                 epayToken,userWalletId,
+          requestBody,
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      export const usePostEpayRequestUserWalletId =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (EpayRequestDetailApiModel), {
+/**
+ * 
+ * User Wallet id
+ */
+userWalletId: number,requestBody: RequestBodyNewEpayRequestInput,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { userWalletId,
+          requestBody,
+          
+           configOverride } = _o || {};
+
+            return postEpayRequestUserWalletId(
+                 userWalletId,
+          requestBody,
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      
+/**
+ * @deprecated This endpoint deprecated and will be remove. Please use an alternative
+ */
+export const usePostSubUserNotificationUserWalletId =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions<string, {
+/**
+ * 
+ * UserWallet's Id
+ */
+userWalletId: number,requestBody: RequestBodySubUserNotificationStatusInput,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { userWalletId,
+          requestBody,
+          
+           configOverride } = _o || {};
+
+            return postSubUserNotificationUserWalletId(
+                 userWalletId,
+          requestBody,
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      
+/**
+ * 
+ * Transfer money
+ */
+export const usePostTransferUserWalletId =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (TransferMoneyApiModel), {userWalletId: number,requestBody: RequestBodyTransferMoneyInput,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { userWalletId,
+          requestBody,
+          
+           configOverride } = _o || {};
+
+            return postTransferUserWalletId(
+                 userWalletId,
+          requestBody,
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      
+/**
+ * 
+ * Change sub user connection info
+[Feature just allowed for the business users]
+[Needs secure login]
+ */
+export const usePutBusinessUserConnectionConnectionId =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (SubUserConnectionApiModel), {
+/**
+ * 
+ * Connection Id
+ */
+connectionId: number,requestBody: EditConnectionInfoInput,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { connectionId,
+          requestBody,
+          
+           configOverride } = _o || {};
+
+            return putBusinessUserConnectionConnectionId(
+                 connectionId,
+          requestBody,
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      export const usePutBusinessUserConnectionConnectionIdPermissionUserWalletId =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions<string, {connectionId: number,
+/**
+ * 
+ * Id of Account to edit it's permissios
+ */
+userWalletId: number,requestBody: EditSubUserPermissionInput,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { connectionId,userWalletId,
+          requestBody,
+          
+           configOverride } = _o || {};
+
+            return putBusinessUserConnectionConnectionIdPermissionUserWalletId(
+                 connectionId,userWalletId,
+          requestBody,
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      
+/**
+ * 
+ * Edit user bank
+[Needs secure login]
+ */
+export const usePutUserBankUserBankId =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (UserBankApiModel), {
+/**
+ * 
+ * User bank id
+ */
+userBankId: number,requestBody: RequestBodyUserBankInput,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { userBankId,
+          requestBody,
+          
+           configOverride } = _o || {};
+
+            return putUserBankUserBankId(
+                 userBankId,
+          requestBody,
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        
+      export const usePutUserWalletUserWalletId =<TExtra> (
+           options?:SwaggerTypescriptUseMutationOptions< & (WalletDisplayApiModel), {userWalletId: number,requestBody: RequestBodyAccountCreationApiModel,}, TExtra>,
+           ) => {return useMutation({mutationFn:(_o)=>{
+            const { userWalletId,
+          requestBody,
+          
+           configOverride } = _o || {};
+
+            return putUserWalletUserWalletId(
+                 userWalletId,
+          requestBody,
+          
+           configOverride,
+              )
+          },
+          ...options
+        }
+         )  
+          }
+        "
+`;
+
+exports[`only includes methods ends with Id generate type 1`] = `
+"
+//@ts-nocheck
+/**
+* AUTO_GENERATED Do not change this file directly, use config.ts file instead
+*
+* @version 6
+*/
+
+        
+        export interface AccountBalanceApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"realBalance\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"totalBalance\\": number;}
+        
+        
+        export interface AccountCreationApiModel {\\"automaticSettlement\\"?: boolean;\\"getComissionFromPayer\\"?: boolean;\\"isActive\\"?: boolean;\\"title\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"userBankId\\"?: number;}
+        
+        
+        export interface AccountInfoApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"accountOwnerAvatarUrl\\"?: string;\\"accountOwnerTitle\\"?: string;}
+        
+        
+        export interface AccountPermittedSubUserQuery {
+/**
+ * 
+ * - Format: int64
+ */
+\\"connectionId\\": number;\\"connectionStatus\\": SubUserConnectionStatus;
+/**
+ * 
+ * [Deprecated, use 'ConnectionStatus' instead]
+ * @deprecated Use 'ConnectionStatus' instead.
+ */
+\\"subUserConnectionStatus\\":  & (SubUserConnectionStatus);
+/**
+ * 
+ * - Format: guid
+ */
+\\"subuserId\\": string;\\"subuserStatus\\": SubuserStatus;\\"connectDate\\"?: string;\\"connectionStatusDisplay\\"?: string;\\"disconnectDate\\"?: string;\\"subUserAvatarUrl\\"?: string;\\"subUserContact\\"?: string;\\"subUserPositionTitle\\"?: string;\\"subUserTitle\\"?: string;\\"subuserStatusDisplay\\"?: string;}
+        
+        
+        export interface AccountSettingNotificationStatusApiModel {\\"notificationEnabled\\": boolean;}
+        
+        
+        export enum AccountStatus {Block=\\"Block\\",OK=\\"OK\\"}
+        
+        
+        export interface AggregationApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"count\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"sum\\": number;}
+        
+        
+        export interface AllTransactionsReportApiModel {\\"credits\\"?: ReportApiModel[];\\"debits\\"?: ReportApiModel[];}
+        
+        
+        export interface BankApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"id\\": number;\\"logoUrl\\"?: string;\\"name\\"?: string;}
+        
+        
+        export interface BankReceiptApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionAmount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDate\\": string;\\"failed\\": boolean;\\"type\\": EpayRequestType;\\"createDateDisplay\\"?: string;\\"creatorUserAvatarUrl\\"?: string;\\"creatorUserDisplayName\\"?: string;\\"description\\"?: string;\\"failureMessage\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"operationId\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"payerAccountId\\"?: number;\\"payerAccountName\\"?: string;\\"payerAccountNumber\\"?: string;\\"shareUrl\\"?: string;\\"targetAccountNumber\\"?: string;\\"targetAvatarUrl\\"?: string;\\"targetUserDisplayName\\"?: string;\\"typeDisplay\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"voucherId\\"?: number;}
+        
+        
+        export interface BusinessCategoryApiModel {\\"id\\": BusinessType;\\"title\\"?: string;}
+        
+        
+        export enum BusinessShareType {Person=\\"Person\\",PrivateStock=\\"PrivateStock\\",PublicStock=\\"PublicStock\\",Limited=\\"Limited\\",GeneralPartnership=\\"GeneralPartnership\\",Institute=\\"Institute\\",Cooperative=\\"Cooperative\\"}
+        
+        
+        export enum BusinessType {Ads=\\"Ads\\",Investment=\\"Investment\\",Production=\\"Production\\",Trade=\\"Trade\\",Software=\\"Software\\"}
+        
+        
+        export interface BusinessUserConnectionApiModel {
+/**
+ * 
+ * - Format: guid
+ */
+\\"businessId\\": string;\\"status\\": SubUserConnectionStatus;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"subUserConnectionStatus\\":  & (SubUserConnectionStatus);\\"businessAvatarUrl\\"?: string;\\"businessName\\"?: string;\\"connectDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"connectDateTime\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"connectionId\\"?: number;\\"disconnectDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"disconnectDateTime\\"?: string;\\"positionTitle\\"?: string;\\"statusDisplay\\"?: string;}
+        
+        
+        export enum CallbackType {None=\\"None\\",Redirect=\\"Redirect\\",RedirectWithPost=\\"RedirectWithPost\\",Call=\\"Call\\"}
+        
+        
+        export interface ClientPurchaseInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"instituteCode\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"userWalletId\\": number;\\"driverCode\\"?: string;}
+        
+        
+        export enum ComissionType {Percentage=\\"Percentage\\",Fixed=\\"Fixed\\"}
+        
+        
+        export interface CommissionAmountApiModel {
+/**
+ * 
+ * [Deprecated, use 'CommissionAmount' instead]
+ * - Format: decimal
+ * @deprecated Use CommissionAmount instead.
+ */
+\\"comissionAmount\\": number;
+/**
+ * 
+ * کارمزد
+ * - Format: decimal
+ */
+\\"commissionAmount\\": number;
+/**
+ * 
+ * مبلغ اصلی
+ * - Format: decimal
+ */
+\\"requestAmount\\": number;
+/**
+ * 
+ * جمع مبلغ اصلی و کارمزد
+ * - Format: decimal
+ */
+\\"totalAmount\\": number;}
+        
+        
+        export interface CommissionPolicyApiModel {\\"commissionType\\": ComissionType;\\"logicalAction\\": LogicalActionType;\\"commissionTypeDisplay\\"?: string;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"fixedValue\\"?: number;\\"logicalActionDisplay\\"?: string;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"maxValue\\"?: number;
+/**
+ * 
+ * - Format: double
+ */
+\\"percent\\"?: number;\\"title\\"?: string;\\"value\\"?: string;}
+        
+        
+        export interface ContactApiModel {\\"audienceType\\": UserIdentifierType;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"audienceTypeDisplay\\"?: string;\\"contact\\"?: string;\\"fullName\\"?: string;\\"userDisplayName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\"?: string;\\"userProfileImageLink\\"?: string;}
+        
+        
+        export enum DatePart {Minute=\\"Minute\\",Hour=\\"Hour\\",Day=\\"Day\\",Week=\\"Week\\",Month=\\"Month\\",Year=\\"Year\\",All=\\"All\\"}
+        
+        
+        export interface DateReportApiModelOfDecimal {
+/**
+ * 
+ * - Format: int32
+ */
+\\"day\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"key\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"value\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\": number;\\"dayName\\"?: string;\\"label\\"?: string;\\"monthName\\"?: string;}
+        
+        
+        export interface DateReportApiModelOfInteger {
+/**
+ * 
+ * - Format: int32
+ */
+\\"day\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"key\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"value\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\": number;\\"dayName\\"?: string;\\"label\\"?: string;\\"monthName\\"?: string;}
+        
+        
+        export interface DivideEpayRequestServiceInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"expiresAfterDays\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"invoiceDate\\": string;\\"isAutoRedirect\\": boolean;\\"isBlocking\\": boolean;\\"callBackUrl\\"?: string;\\"description\\"?: string;\\"divisions\\"?: DivideEpayRequestShareModel[];\\"invoiceNumber\\"?: string;}
+        
+        
+        export interface DivideEpayRequestShareModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"dividerAmount\\": number;\\"apiKey\\"?: string;\\"invoiceNumber\\"?: string;}
+        
+        
+        export interface DividedEpayRequestCancelInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"dividerAmount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"userAmount\\": number;\\"description\\"?: string;\\"firstName\\"?: string;\\"invoiceNumber\\"?: string;\\"lastName\\"?: string;\\"paymentToken\\"?: string;\\"shebaNo\\"?: string;\\"userApiKey\\"?: string;}
+        
+        
+        export interface DividedEpayRequestCancelResult {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"cancelledAmount\\": number;}
+        
+        
+        export interface DividedEpayRequestUnblockInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"dividerAmount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"userAmount\\": number;\\"description\\"?: string;\\"invoiceNumber\\"?: string;\\"paymentToken\\"?: string;\\"userApiKey\\"?: string;}
+        
+        
+        export interface DividedEpayRequestUnblockResult {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"unblockedAmount\\": number;}
+        
+        
+        export interface DocumentApiModel {\\"contentType\\": DocumentContentType;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDate\\": string;
+/**
+ * 
+ * [Deprecated, use 'ContentType' instead]
+ * @deprecated Use 'ContentType' instead.
+ */
+\\"documentContentType\\":  & (DocumentContentType);
+/**
+ * 
+ * - Format: int64
+ */
+\\"fileSize\\": number;\\"fileType\\": FileTypes;
+/**
+ * 
+ * [Deprecated, use 'FileType' instead]
+ * @deprecated Use 'FileType' instead.
+ */
+\\"fileTypes\\":  & (FileTypes);
+/**
+ * 
+ * - Format: guid
+ */
+\\"uniqueId\\": string;\\"contentTypeDisplay\\"?: string;\\"fileName\\"?: string;\\"fileTypeDisplay\\"?: string;\\"fileUrl\\"?: string;}
+        
+        
+        export enum DocumentContentType {Other=\\"Other\\",UserBankVerification=\\"UserBankVerification\\",IdentityCard=\\"IdentityCard\\",BusinessStatute=\\"BusinessStatute\\",BusinessLatestChangesAnnouncement=\\"BusinessLatestChangesAnnouncement\\",BusinessOwnersIdentityCards=\\"BusinessOwnersIdentityCards\\",BusinessOwnersBirthCertificates=\\"BusinessOwnersBirthCertificates\\"}
+        
+        
+        export interface DocumentInput {\\"documentContentType\\": DocumentContentType;
+/**
+ * 
+ * - Format: guid
+ */
+\\"fileUniqueId\\": string;}
+        
+        
+        export interface DriverInfoResult {\\"barcodType\\": number;\\"barcodTypeDescription\\"?: string;\\"customData\\"?:  & (TaxiInfoOutput);\\"firstName\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"identificationCode\\"?: number;\\"identificationDesc\\"?: string;\\"imageUrl\\"?: string;\\"lastName\\"?: string;\\"nationalCode\\"?: string;\\"price\\"?: TaxiPriceOutput[];}
+        
+        
+        export interface DropDownResultItemOfIdentityStatus {\\"value\\": IdentityStatus;\\"display\\"?: string;}
+        
+        
+        export interface DropDownResultOfIdentityStatus {\\"items\\"?: DropDownResultItemOfIdentityStatus[];}
+        
+        
+        export interface EPayPluginSpecificApiModel {\\"id\\"?: string;\\"persianName\\"?: string;
+/**
+ * 
+ * [Deprecated, don't use this property anymore, it is always null]
+ * @deprecated Don't use this property anymore, it is always null.
+ */
+\\"pluginPropertyId\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'Id' instead]
+ * @deprecated Use 'Id' instead.
+ */
+\\"pluginPropertyName\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'PersianName' instead]
+ * @deprecated Use 'PersianName' instead.
+ */
+\\"pluginPropertyPersianName\\"?: string;\\"value\\"?: string;}
+        
+        
+        export interface EPayRequestAudienceInput {\\"contact\\"?: string;\\"fullName\\"?: string;}
+        
+        
+        export interface EditConnectionInfoInput {\\"position\\"?: string;}
+        
+        
+        export interface EditSubUserPermissionInput {\\"isEnabled\\"?: boolean;\\"subUserPermissionType\\"?:  & (SubUserPermissionType);}
+        
+        
+        export enum EpayRequestActualState {Initiated=\\"Initiated\\",Paid=\\"Paid\\",Cancelled=\\"Cancelled\\",Expired=\\"Expired\\"}
+        
+        
+        export interface EpayRequestApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"epayRequestStatus\\":  & (EpayRequestStatus);
+/**
+ * 
+ * - Format: date-time
+ */
+\\"expireDateTime\\": string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"status\\": EpayRequestActualState;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"assistantDisplayName\\"?: string;\\"assistantPositionTitle\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"assistantUserId\\"?: string;\\"createDate\\"?: string;\\"description\\"?: string;
+/**
+ * 
+ * [Deprecated, don't use EpayRequestAudience]
+ * @deprecated Don't use EpayRequestAudience.
+ */
+\\"epayRequestAudience\\"?: EPayRequestAudienceInput[];\\"expireDate\\"?: string;\\"payDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"payDateTime\\"?: string;\\"payerName\\"?: string;\\"paymentLink\\"?: string;\\"qrCodeLink\\"?: string;\\"statusDisplay\\"?: string;\\"targetDisplayName\\"?: string;\\"userAccountName\\"?: string;}
+        
+        
+        export interface EpayRequestCheckStatusResult {\\"requestStatus\\": EpayRequestStatus;\\"bankReferenceId\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"verifyDate\\"?: string;}
+        
+        
+        export interface EpayRequestDetailApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * [Deprecated, use 'CommissionAmount' instead]
+ * - Format: decimal
+ * @deprecated Use 'CommissionAmount' instead.
+ */
+\\"comissionAmount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionAmount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"epayRequestStatus\\":  & (EpayRequestStatus);
+/**
+ * 
+ * - Format: date-time
+ */
+\\"expireDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'GetCommissionFromPayer' instead]
+ * @deprecated Use 'GetCommissionFromPayer' instead.
+ */
+\\"getComissionByPayer\\": boolean;\\"getCommissionFromPayer\\": boolean;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"status\\": EpayRequestActualState;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"assistantDisplayName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"assistantUserId\\"?: string;\\"audiences\\"?: ContactApiModel[];\\"description\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'Audiences' instead]
+ * @deprecated Use 'Audiences' instead.
+ */
+\\"epayRequestAudience\\"?: ContactApiModel[];
+/**
+ * 
+ * [Deprecated, use 'PluginProperties' instead]
+ * @deprecated Use 'PluginProperties' instead.
+ */
+\\"epayRequestPluginSpecific\\"?: EPayPluginSpecificApiModel[];
+/**
+ * 
+ * - Format: date-time
+ */
+\\"payDateTime\\"?: string;\\"paymentLink\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"pluginId\\"?: number;\\"pluginName\\"?: string;\\"pluginProperties\\"?: EPayPluginSpecificApiModel[];\\"publicLink\\"?: string;\\"qrCodeLink\\"?: string;\\"statusDisplay\\"?: string;\\"token\\"?: string;\\"userAccountName\\"?: string;}
+        
+        
+        export interface EpayRequestForUserQuery {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * [Deprecated, don't use this property anymore]
+ * @deprecated Don't use this property anymore.
+ */
+\\"canBeCanceled\\": boolean;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"epayRequestStatus\\":  & (EpayRequestStatus);
+/**
+ * 
+ * - Format: date-time
+ */
+\\"expireDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'Token' for EPays that created by others]
+ * - Format: int64
+ * @deprecated Use 'Token' for EPays that created by others.
+ */
+\\"id\\": number;\\"status\\": EpayRequestActualState;
+/**
+ * 
+ * [Deprecated, use 'UserDisplayName' instead]
+ * @deprecated Use 'UserDisplayName' instead.
+ */
+\\"applicantName\\"?: string;\\"createDate\\"?: string;\\"description\\"?: string;\\"expireDate\\"?: string;\\"paymentUrl\\"?: string;\\"statusDisplay\\"?: string;\\"token\\"?: string;\\"userAccountNumber\\"?: string;\\"userDisplayName\\"?: string;}
+        
+        
+        export interface EpayRequestPayInput {\\"description\\"?: string;}
+        
+        
+        export interface EpayRequestPluginSpecificInput {\\"pluginPropertyId\\"?: string;\\"value\\"?: string;}
+        
+        
+        export interface EpayRequestPublicInfoApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"expireDate\\": string;\\"status\\": EpayRequestStatus;\\"description\\"?: string;\\"expireDateDisplay\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"payDate\\"?: string;\\"payDateDisplay\\"?: string;\\"payerName\\"?: string;\\"paymentUrl\\"?: string;\\"statusDisplay\\"?: string;\\"token\\"?: string;\\"userAccountNumber\\"?: string;\\"userAvatarUrl\\"?: string;\\"userDisplayName\\"?: string;}
+        
+        
+        export interface EpayRequestServiceInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"callbackType\\": CallbackType;
+/**
+ * 
+ * - Format: guid
+ */
+\\"clientId\\": string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"domainId\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"expiresAfterDays\\": number;\\"getComissionFromPayer\\": boolean;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"invoiceDate\\": string;\\"isAutoConfirm\\": boolean;\\"isAutoRedirect\\": boolean;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userAccountId\\": number;
+/**
+ * 
+ * - Format: guid
+ * - minLength: 1
+ */
+\\"userId\\": string;\\"audiences\\"?: EPayRequestAudienceInput[];\\"callbackUrl\\"?: string;\\"description\\"?: string;\\"invoiceNumber\\"?: string;}
+        
+        
+        export enum EpayRequestStatus {Initiated=\\"Initiated\\",Paid=\\"Paid\\",Cancelled=\\"Cancelled\\",Expired=\\"Expired\\",Viewed=\\"Viewed\\"}
+        
+        
+        export interface EpayRequestTaskInput {\\"epayRequestTaskType\\": EpayRequestTaskType;}
+        
+        
+        export enum EpayRequestTaskType {Resend=\\"Resend\\",Cancel=\\"Cancel\\"}
+        
+        
+        export enum EpayRequestType {Link=\\"Link\\",POS=\\"POS\\",Divide=\\"Divide\\",DivideWithBlock=\\"DivideWithBlock\\",Charge=\\"Charge\\",IPG=\\"IPG\\"}
+        
+        
+        export interface EpayRequestWcfResult {\\"paymentUrl\\"?: string;\\"requestToken\\"?: string;}
+        
+        
+        export enum FieldDisplayType {String=\\"String\\",Text=\\"Text\\",Currency=\\"Currency\\",Integer=\\"Integer\\",Float=\\"Float\\",Boolean=\\"Boolean\\",List=\\"List\\"}
+        
+        
+        export interface FileApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"fileSize\\": number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"uniqueId\\": string;\\"fileName\\"?: string;\\"fileUrl\\"?: string;}
+        
+        
+        export enum FileTypes {Other=\\"Other\\",Image=\\"Image\\",Pdf=\\"Pdf\\"}
+        
+        
+        export interface ForgetPasswordQuery {\\"token\\"?: string;}
+        
+        
+        export interface FullRegisterApiModel {\\"fullName\\"?: string;\\"introducerCode\\"?: string;\\"phoneNumber\\"?: string;}
+        
+        
+        export enum Gender {Unknown=\\"Unknown\\",Male=\\"Male\\",Female=\\"Female\\"}
+        
+        
+        export interface GroupTransferInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"totalAmount\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"description\\"?: string;\\"targets\\"?: GroupTransferTargetInput[];}
+        
+        
+        export interface GroupTransferQuery {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDate\\": string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"voucherId\\": number;\\"createDateDisplay\\"?: string;\\"description\\"?: string;\\"targets\\"?: GroupTransferTargetQuery[];\\"userAccountName\\"?: string;\\"userDisplayName\\"?: string;}
+        
+        
+        export interface GroupTransferTargetInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"description\\"?: string;\\"identifier\\"?: string;}
+        
+        
+        export interface GroupTransferTargetQuery {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"accountName\\"?: string;\\"description\\"?: string;\\"userDisplayName\\"?: string;\\"userPhoneNumber\\"?: string;}
+        
+        
+        export enum GroupTransferTargetStatus {InvalidIdentifier=\\"InvalidIdentifier\\",Ok=\\"Ok\\",Unregistered=\\"Unregistered\\",BlockedAccount=\\"BlockedAccount\\",InvalidAmount=\\"InvalidAmount\\"}
+        
+        
+        export interface GroupTransferTargetValidationInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"description\\"?: string;
+/**
+ * 
+ * PhoneNumber or Account Number
+ */
+\\"identifier\\"?: string;}
+        
+        
+        export interface GroupTransferTargetValidationQuery {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"identifierType\\": UserIdentifierType;\\"status\\": GroupTransferTargetStatus;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userCustomerNumber\\": number;\\"accountNumber\\"?: string;\\"identifier\\"?: string;\\"identifierTypeDisplay\\"?: string;\\"name\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'StatusDisplay' instead]
+ * @deprecated Use 'StatusDisplay' instead.
+ */
+\\"statusDescription\\"?: string;\\"statusDisplay\\"?: string;\\"userDisplayName\\"?: string;\\"userPhoneNumber\\"?: string;}
+        
+        
+        export enum IPGStatus {NotRequested=\\"NotRequested\\"}
+        
+        
+        export enum IdentityStatus {None=\\"None\\",WatingForCheck=\\"WatingForCheck\\",Checking=\\"Checking\\",EditingRequired=\\"EditingRequired\\",Approved=\\"Approved\\",Rejected=\\"Rejected\\"}
+        
+        
+        export interface ImportantActionApiModel {\\"closeable\\": boolean;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createTime\\": string;\\"dismissible\\": boolean;
+/**
+ * 
+ * - Format: int32
+ */
+\\"id\\": number;\\"isSeen\\": boolean;\\"level\\": NotificationLevel;\\"type\\": NotificationModelType;\\"data\\"?: string;\\"dataId\\"?: string;\\"levelDisplay\\"?: string;\\"text\\"?: string;\\"title\\"?: string;\\"typeDisplay\\"?: string;}
+        
+        
+        export interface InitApiModel {\\"versionState\\": TerminalVersionState;\\"appDownloadLink\\"?: string;\\"versionStateDisplay\\"?: string;}
+        
+        
+        export interface KpiResult {
+/**
+ * 
+ * - Format: date-time
+ */
+\\"end\\": string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"start\\": string;\\"datePart\\"?:  & (DatePart);\\"kpiName\\"?: string;\\"targetIds\\"?: string[];\\"values\\"?: KpiResultValue[];}
+        
+        
+        export interface KpiResultValue {
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endPoint\\": string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"extractedTime\\": string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startPoint\\": string;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"value\\": number;\\"targetId\\"?: string;}
+        
+        
+        export enum LogEventLevel {Verbose=\\"Verbose\\",Debug=\\"Debug\\",Information=\\"Information\\",Warning=\\"Warning\\",Error=\\"Error\\",Fatal=\\"Fatal\\"}
+        
+        
+        export interface LogSetting {\\"globalLogLevel\\": LogEventLevel;\\"septaPayLogLevel\\": LogEventLevel;\\"serilogLogLevel\\": LogEventLevel;}
+        
+        
+        export enum LogicalActionType {EpayRequest=\\"EpayRequest\\",TransferMoney=\\"TransferMoney\\",AccountChargeRequest=\\"AccountChargeRequest\\",ServiceBill=\\"ServiceBill\\",ServiceMobileCharge=\\"ServiceMobileCharge\\",POS=\\"POS\\",ShareAndBlockRequest=\\"ShareAndBlockRequest\\",ShareRequest=\\"ShareRequest\\",Settlement=\\"Settlement\\",GroupTransferMoney=\\"GroupTransferMoney\\",ShareAndUnblock=\\"ShareAndUnblock\\",Refund=\\"Refund\\",PayCommand=\\"PayCommand\\",Gift=\\"Gift\\",TaxiFairPayment=\\"TaxiFairPayment\\",HitoBitFee=\\"HitoBitFee\\"}
+        
+        
+        export interface MachineSignUp {
+/**
+ * 
+ * - Format: int64
+ */
+\\"customerNumber\\": number;\\"apiKey\\"?: string;}
+        
+        
+        export interface NewChargeRequestInput {
+/**
+ * 
+ * مبلغ شارژ
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * آدرس بازگشت بعد از پرداخت
+ */
+\\"callbackUrl\\"?: string;}
+        
+        
+        export interface NewChargeRequestResultQuery {\\"paymentLink\\"?: string;}
+        
+        
+        export interface NewEpayRequestInput {
+/**
+ * 
+ * مبلغ شارژ
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * نوع ارجاع در هنگام ایجاد درخواست
+ */
+\\"callbackType\\":  & (CallbackType);
+/**
+ * 
+ * تاریخ انتقضا لینک ایجاد شده
+ * - Format: int32
+ */
+\\"expireDays\\": number;
+/**
+ * 
+ * انتقال مستقیم به درگاه
+ 
+ */
+\\"isAutoConfirm\\": boolean;
+/**
+ * 
+ * - Format: guid
+ */
+\\"assisstantUserId\\"?: string;
+/**
+ * 
+ * اطلاعات پرداخت کننده / ها
+ */
+\\"audiences\\"?: EPayRequestAudienceInput[];
+/**
+ * 
+ * آدرس بازگشت بعد از پرداخت
+ */
+\\"callbackUrl\\"?: string;
+/**
+ * 
+ * توضحیات درخواست (بابت)
+ */
+\\"description\\"?: string;
+/**
+ * 
+ * نحوه دریافت کارمزد
+ */
+\\"getComissionByPayer\\"?: boolean;
+/**
+ * 
+ * تاریخ فاکتور
+ * - Format: date-time
+ */
+\\"invoiceDate\\"?: string;
+/**
+ * 
+ * شماره فاکتور
+ */
+\\"invoiceNumber\\"?: string;
+/**
+ * 
+ * ...
+ * - Format: int32
+ */
+\\"pluginId\\"?: number;
+/**
+ * 
+ * ...
+ */
+\\"pluginSpecifics\\"?: EpayRequestPluginSpecificInput[];}
+        
+        
+        export interface NewUserIdentityRequestInput {\\"documents\\"?: DocumentInput[];\\"firstName\\"?: string;\\"lastName\\"?: string;\\"nationalCode\\"?: string;}
+        
+        
+        export interface NotificationApiModel {
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createTime\\": string;\\"isSeen\\": boolean;\\"level\\": NotificationLevel;\\"type\\": NotificationModelType;\\"dataId\\"?: string;\\"levelDisplay\\"?: string;\\"text\\"?: string;\\"title\\"?: string;\\"typeDisplay\\"?: string;}
+        
+        
+        export enum NotificationChannel {Notification=\\"Notification\\",ImportantAction=\\"ImportantAction\\",SMS=\\"SMS\\",Email=\\"Email\\",FCM=\\"FCM\\",SignalR=\\"SignalR\\"}
+        
+        
+        export enum NotificationLevel {Unknown=\\"Unknown\\",Default=\\"Default\\",Success=\\"Success\\",Info=\\"Info\\",Warning=\\"Warning\\",Danger=\\"Danger\\"}
+        
+        
+        export enum NotificationModelType {Default=\\"Default\\",EPayRequestUnpaid=\\"EPayRequestUnpaid\\",EPayRequestPaid=\\"EPayRequestPaid\\",UserIdentityUnknown=\\"UserIdentityUnknown\\",UserIdentityApproved=\\"UserIdentityApproved\\",UserIdentityRejected=\\"UserIdentityRejected\\",UpgradeToBusinessApproved=\\"UpgradeToBusinessApproved\\",UpgradeToBusinessRejected=\\"UpgradeToBusinessRejected\\",UserBankApproved=\\"UserBankApproved\\",UserBankRejected=\\"UserBankRejected\\",SubUserConnectionCreated=\\"SubUserConnectionCreated\\",SubUserInvitationRejected=\\"SubUserInvitationRejected\\",SubUserInvitationSent=\\"SubUserInvitationSent\\",MoneyDeposit=\\"MoneyDeposit\\",MoneyWithdrawal=\\"MoneyWithdrawal\\",SubUserDisconnectedByBusiness=\\"SubUserDisconnectedByBusiness\\",SubUserDisconnectedBySubUser=\\"SubUserDisconnectedBySubUser\\",Activities=\\"Activities\\",TradeNotification=\\"TradeNotification\\",HitoBitNews=\\"HitoBitNews\\",SystemMessages=\\"SystemMessages\\"}
+        
+        
+        export enum PlatformType {Unknown=\\"Unknown\\",Server=\\"Server\\",Android=\\"Android\\",iOS=\\"iOS\\",Device=\\"Device\\",Browser=\\"Browser\\",PWA=\\"PWA\\",Web=\\"Web\\",Windows=\\"Windows\\",Linux=\\"Linux\\",macOS=\\"macOS\\",Desktop=\\"Desktop\\"}
+        
+        
+        export interface PluginApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"id\\": number;\\"amountCalculationExpression\\"?: string;\\"logoFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"logoFileUniqueId\\"?: string;\\"logoFileUrl\\"?: string;\\"name\\"?: string;\\"properties\\"?: PluginPropertyApiModel[];}
+        
+        
+        export interface PluginPropertyApiModel {\\"fieldType\\": FieldDisplayType;\\"isFilterable\\": boolean;\\"isRequired\\": boolean;\\"currencyName\\"?: string;\\"description\\"?: string;\\"name\\"?: string;\\"title\\"?: string;\\"value\\"?: string;}
+        
+        
+        export interface PosLandingPageApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"domainId\\": number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"accountNumber\\"?: string;\\"domainEnglishName\\"?: string;\\"domainLogoFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"domainLogoFileUniqueId\\"?: string;\\"domainLogoFileUrl\\"?: string;\\"domainPersianName\\"?: string;\\"getCommissionFromPayer\\"?: boolean;\\"subUserAvatarFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"subUserAvatarFileUniqueId\\"?: string;\\"subUserAvatarFileUrl\\"?: string;\\"subUserDisplayName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"subUserId\\"?: string;\\"userAvatarFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userAvatarFileUniqueId\\"?: string;\\"userAvatarFileUrl\\"?: string;\\"userDisplayName\\"?: string;}
+        
+        
+        export interface PosOnlinePayInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;\\"callBackUrl\\"?: string;\\"callbackType\\"?:  & (CallbackType);\\"description\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"subuserId\\"?: string;}
+        
+        
+        export interface PosWalletPayInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"description\\"?: string;}
+        
+        
+        export interface RegisterApiModel {\\"deviceBrandName\\"?: string;\\"deviceId\\"?: string;\\"deviceOsVersion\\"?: string;\\"deviceToken\\"?: string;\\"phoneNumber\\"?: string;}
+        
+        
+        export interface RegisterNewUserQuery {
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"token\\"?: string;}
+        
+        
+        export interface ReportApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"count\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"day\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"dayOfWeek\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"key\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"month\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"sum\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"year\\": number;\\"dayName\\"?: string;\\"label\\"?: string;\\"monthName\\"?: string;
+/**
+ * 
+ * سال دو رقمی
+ */
+\\"yearShort\\"?: string;}
+        
+        
+        export type RequestBodyAccountCreationApiModel = AccountCreationApiModel
+        
+        
+        export interface RequestBodyFile_Upload {
+/**
+ * 
+ * - Format: binary
+ */
+\\"file\\"?: string;}
+        
+        
+        export type RequestBodyLogEventLevel = LogEventLevel
+        
+        
+        export type RequestBodyNewEpayRequestInput = NewEpayRequestInput
+        
+        
+        export type RequestBodySubUserNotificationStatusInput = SubUserNotificationStatusInput
+        
+        
+        export type RequestBodyTransferMoneyInput = TransferMoneyInput
+        
+        
+        export type RequestBodyUserBankInput = UserBankInput
+        
+        
+        export interface RequestTotpInput {\\"phoneNumber\\"?: string;}
+        
+        
+        export interface ReselledUserActivityApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"commissionsPaidToResellerCount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionsPaidToResellerSum\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"generatedLinks\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"paidGeneratedLinks\\": number;}
+        
+        
+        export interface ReselledUserApiModel {\\"identityStatus\\": IdentityStatus;\\"ipgStatus\\": IPGStatus;\\"isActive\\": boolean;\\"isBussinessUser\\": boolean;\\"isPerson\\": boolean;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"userStatus\\": UserStatus;\\"displayName\\"?: string;\\"identityStatusDisplay\\"?: string;\\"imageUrl\\"?: string;\\"ipgStatusDisplay\\"?: string;\\"lastActivityDate\\"?: string;\\"phoneNumber\\"?: string;\\"registerDate\\"?: string;}
+        
+        
+        export interface ReselledUserFilterData {\\"identityStatuses\\"?:  & (DropDownResultOfIdentityStatus);}
+        
+        
+        export interface ResellerApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"commissionId\\": number;\\"commissionType\\": ComissionType;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"endDate\\": string;\\"hasSubDomain\\": boolean;\\"isActive\\": boolean;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"startDate\\": string;\\"commissionDisplay\\"?: string;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionFixedValue\\"?: number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionMaxValue\\"?: number;\\"commissionName\\"?: string;
+/**
+ * 
+ * - Format: double
+ */
+\\"commissionPercent\\"?: number;\\"commissionTypeDisplay\\"?: string;\\"endDateDisplay\\"?: string;\\"introduceLink\\"?: string;\\"startDateDisplay\\"?: string;}
+        
+        
+        export interface SendConnectionRequestInput {\\"email\\"?: string;\\"phoneNumber\\"?: string;\\"position\\"?: string;}
+        
+        
+        export enum SepidResponseType {Succesful=\\"Succesful\\",Unsuccesful=\\"Unsuccesful\\"}
+        
+        
+        export interface SetAccountAccessForSubUserInput {
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\"?: number;}
+        
+        
+        export interface SetUserBasicInfoInput {
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"firstName\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"introducerCode\\"?: number;\\"lastName\\"?: string;\\"password\\"?: string;}
+        
+        
+        export interface SettingApiModel {\\"logSetting\\"?:  & (LogSetting);}
+        
+        
+        export interface SubDomainApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"domainId\\": number;\\"isActive\\": boolean;
+/**
+ * 
+ * - Format: guid
+ */
+\\"resellerUserId\\": string;\\"about\\"?: string;\\"domainEnglishName\\"?: string;\\"domainPersianName\\"?: string;\\"englishName\\"?: string;\\"logoFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"logoFileUniqueId\\"?: string;\\"logoFileUrl\\"?: string;\\"persianName\\"?: string;\\"resellerUserDisplayName\\"?: string;\\"subDomainAddress\\"?: string;}
+        
+        
+        export interface SubDomainUpdateApiModel {\\"about\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"logoFileUniqueId\\"?: string;}
+        
+        
+        export interface SubUserAccountDetailQuery {\\"accountStatus\\": AccountStatus;\\"canAssistantsCreatesEpayRequest\\": boolean;\\"canChargeAccount\\": boolean;\\"canReceiveMoney\\": boolean;\\"canRequestSettlement\\": boolean;\\"canSeeEpayRequests\\": boolean;\\"canSeeSettlementRequests\\": boolean;\\"canSeeTransactions\\": boolean;\\"canTransferMoney\\": boolean;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"isActive\\": boolean;\\"notificationEnabled\\": boolean;
+/**
+ * 
+ * - Format: int32
+ */
+\\"posPaidCount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"posScanCount\\": number;\\"accountNumber\\"?: string;\\"accountQrCodeUrl\\"?: string;\\"accountStatusDisplay\\"?: string;\\"name\\"?: string;\\"posLinkUrl\\"?: string;}
+        
+        
+        export interface SubUserActivityApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"accountChargeRequestAmount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"accountChargeRequestCount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"paidEpayRequestAmount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"paidEpayRequestCount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"settlementRequestAmount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"settlementRequestCount\\": number;}
+        
+        
+        export interface SubUserConnectionApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"invitationId\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"requestDateTime\\": string;\\"status\\": SubUserConnectionStatus;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead,
+ */
+\\"subUserConnectionStatus\\":  & (SubUserConnectionStatus);\\"connectDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"connectDateTime\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"connectionId\\"?: number;\\"disconnectDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"disconnectDateTime\\"?: string;\\"removeDate\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"removeDateTime\\"?: string;\\"requestDate\\"?: string;\\"statusDisplay\\"?: string;\\"subUserAvatarUrl\\"?: string;\\"subUserContact\\"?: string;\\"subUserPositionTitle\\"?: string;\\"subUserTitle\\"?: string;}
+        
+        
+        export enum SubUserConnectionStatus {Pending=\\"Pending\\",Rejected=\\"Rejected\\",Connected=\\"Connected\\",Disconnected=\\"Disconnected\\",Deleted=\\"Deleted\\"}
+        
+        
+        export interface SubUserInvitationApiModel {
+/**
+ * 
+ * - Format: date-time
+ */
+\\"invitationDate\\": string;
+/**
+ * 
+ * [Deprecated, use 'InvitationToken' to call new endpoints]
+ * - Format: int64
+ * @deprecated Use 'InvitationToken' to call new endpoints.
+ */
+\\"invitationId\\": number;\\"businessUserAvatarUrl\\"?: string;\\"businessUserTitle\\"?: string;\\"invitationToken\\"?: string;\\"message\\"?: string;}
+        
+        
+        export interface SubUserNotificationStatusInput {\\"notificationEnabled\\": boolean;}
+        
+        
+        export interface SubUserPermissionApiModel {\\"canAccessToAccount\\": boolean;\\"canAssistantsCreatesEpayRequest\\": boolean;\\"canChargeAccount\\": boolean;\\"canGroupTransferMoney\\": boolean;\\"canReceiveMoney\\": boolean;\\"canRequestSettlement\\": boolean;\\"canSeeEpayRequests\\": boolean;\\"canSeeSettlementRequests\\": boolean;\\"canSeeTransactions\\": boolean;\\"canTransferMoney\\": boolean;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"realBalance\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"totalBalance\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"userWalletId\\": number;\\"accountNumber\\"?: string;\\"accountTitle\\"?: string;}
+        
+        
+        export enum SubUserPermissionType {Default=\\"Default\\",CanReceiveMoney=\\"CanReceiveMoney\\",CanSeeEpayRequests=\\"CanSeeEpayRequests\\",CanTransferMoney=\\"CanTransferMoney\\",CanSeeTransactions=\\"CanSeeTransactions\\",CanRequestSettlement=\\"CanRequestSettlement\\",CanChargeAccount=\\"CanChargeAccount\\",CanSeeSettlementRequests=\\"CanSeeSettlementRequests\\",CanGroupTransferMoney=\\"CanGroupTransferMoney\\",CanAssistantsCreatesEpayRequest=\\"CanAssistantsCreatesEpayRequest\\"}
+        
+        
+        export interface SubuserInvitationTaskInput {\\"subuserInvitationTaskType\\": SubuserInvitationTaskType;}
+        
+        
+        export enum SubuserInvitationTaskType {Accept=\\"Accept\\",Reject=\\"Reject\\"}
+        
+        
+        export enum SubuserStatus {Connected=\\"Connected\\",DisconnectedByBusinessUser=\\"DisconnectedByBusinessUser\\",DisconnectedBySubUser=\\"DisconnectedBySubUser\\"}
+        
+        
+        export interface TaxiInfoOutput {\\"carTypeCode\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"lineCode\\": number;\\"activityType\\"?: string;\\"destination\\"?: string;\\"source\\"?: string;\\"vehicleColor\\"?: string;\\"vehicleType\\"?: string;}
+        
+        
+        export enum TaxiPaymentProvider {Sepid=\\"Sepid\\",Simorgh=\\"Simorgh\\"}
+        
+        
+        export interface TaxiPriceOutput {
+/**
+ * 
+ * - Format: int64
+ */
+\\"amount\\": number;\\"currency\\"?: string;\\"title\\"?: string;}
+        
+        
+        export interface TaxiRecieptApiDto {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"dateTime\\": string;\\"sepidResponse\\": SepidResponseType;\\"taxiProvider\\": TaxiPaymentProvider;\\"accountName\\"?: string;\\"accountNumber\\"?: string;\\"sepidResponseDisplay\\"?: string;\\"taxiProviderDisplay\\"?: string;}
+        
+        
+        export interface TerminalVersionApiModel {\\"currentVersion\\"?: string;\\"minimumVersion\\"?: string;}
+        
+        
+        export enum TerminalVersionState {Default=\\"Default\\",UpToDate=\\"UpToDate\\",Supported=\\"Supported\\",Deprecated=\\"Deprecated\\"}
+        
+        
+        export interface TotpLoginResult {\\"token\\"?: string;}
+        
+        
+        export interface TransactionApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"accountId\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDateTime\\": string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"remain\\": number;\\"transactionOperationType\\": TransactionOperationType;\\"transactionType\\": TransactionType;
+/**
+ * 
+ * - Format: int64
+ */
+\\"voucherId\\": number;\\"accountNumber\\"?: string;\\"accountTitle\\"?: string;\\"createDate\\"?: string;\\"description\\"?: string;\\"followupId\\"?: string;\\"logicalAction\\"?:  & (LogicalActionType);\\"logicalActionDisplay\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"targetBusinessCategoryId\\"?: number;\\"targetBusinessCategoryName\\"?: string;\\"transactionOperationTypeDisplay\\"?: string;\\"transactionTypeDisplay\\"?: string;\\"voucherType\\"?:  & (VoucherOperationType);\\"voucherTypeDisplay\\"?: string;}
+        
+        
+        export enum TransactionOperationType {Unknown=\\"Unknown\\",Normal=\\"Normal\\",System=\\"System\\",DomainCommission=\\"DomainCommission\\",ResellerCommission=\\"ResellerCommission\\",Block=\\"Block\\",Unblock=\\"Unblock\\",Refund=\\"Refund\\",NoCommissionRemainGift=\\"NoCommissionRemainGift\\",RemainGift=\\"RemainGift\\",DomainBankBatchTransfer=\\"DomainBankBatchTransfer\\",SettlementBatchTransferItem=\\"SettlementBatchTransferItem\\",Synchronization=\\"Synchronization\\",BlockchainWithdrawInternalTransfer=\\"BlockchainWithdrawInternalTransfer\\",BlockchainWithdrawUserWallet=\\"BlockchainWithdrawUserWallet\\",BlockchainIncomingTransaction=\\"BlockchainIncomingTransaction\\",BlockchainWithdrawUserWalletOffchain=\\"BlockchainWithdrawUserWalletOffchain\\",BlockchainFee=\\"BlockchainFee\\"}
+        
+        
+        export enum TransactionType {Debt=\\"Debt\\",Credit=\\"Credit\\"}
+        
+        
+        export interface TransferMoneyApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionAmount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDateTime\\": string;
+/**
+ * 
+ * [Deprecated, use 'CommissionAmount' instead]
+ * - Format: decimal
+ * @deprecated Use 'CommissionAmount' instead.
+ */
+\\"domainCommissionAmount\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"payerAccountId\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"targetAccountId\\": number;
+/**
+ * 
+ * [Deprecated, use 'PayerAccountId' instead]
+ * - Format: int64
+ * @deprecated Use 'PayerAccountId' instead.
+ */
+\\"userAccountId\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"voucherId\\": number;\\"description\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'OperationId' instead]
+ * - Format: int64
+ * @deprecated Use 'OperationId' instead.
+ */
+\\"id\\"?: number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"operationId\\"?: number;\\"payerAccountName\\"?: string;\\"payerAccountNumber\\"?: string;\\"targetAccountNumber\\"?: string;\\"targetUserAvatarUrl\\"?: string;\\"targetUserDisplayName\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'PayerAccountName' instead]
+ * @deprecated Use 'PayerAccountName' instead.
+ */
+\\"userAccountName\\"?: string;}
+        
+        
+        export interface TransferMoneyInput {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: int64
+ */
+\\"targetUserAccountId\\": number;\\"description\\"?: string;\\"targetIdentifier\\"?: string;}
+        
+        
+        export interface UnreadNotificationCountApiModel {\\"channel\\": NotificationChannel;
+/**
+ * 
+ * - Format: int32
+ */
+\\"unreadCount\\": number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;}
+        
+        
+        export interface UpgradeToBusinessApiModel {\\"businessShareType\\": BusinessShareType;\\"businessType\\": BusinessType;\\"status\\": IdentityStatus;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"upgradeToBusinessRequestStatus\\":  & (IdentityStatus);
+/**
+ * 
+ * [Deprecated, use 'BusinessShareType' instead]
+ * @deprecated Use 'BusinessShareType' instead.
+ */
+\\"userIdentityType\\":  & (BusinessShareType);\\"address\\"?: string;\\"businessLogoImageLink\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"businessLogoImageUniqueId\\"?: string;\\"businessName\\"?: string;\\"businessShareTypeDisplay\\"?: string;\\"businessTypeDisplay\\"?: string;\\"city\\"?: string;\\"description\\"?: string;\\"documents\\"?: DocumentApiModel[];\\"email\\"?: string;\\"faxNumber\\"?: string;\\"managerName\\"?: string;\\"managerPhoneNumber\\"?: string;\\"organizationName\\"?: string;\\"organizationNationalCode\\"?: string;\\"personNationalCode\\"?: string;\\"phoneNumber\\"?: string;\\"rejectCause\\"?:  & (UpgradeToBusinessRejectCause);\\"rejectCauseDescription\\"?: string;\\"rejectCauseDisplay\\"?: string;\\"state\\"?: string;\\"statusDisplay\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'RejectCauseDescription' instead]
+ * @deprecated Use 'RejectCauseDescription' instead.
+ */
+\\"upgradeToBusinessRequestStatusDescription\\"?: string;\\"webSiteUrl\\"?: string;}
+        
+        
+        export enum UpgradeToBusinessRejectCause {DocumentsLack=\\"DocumentsLack\\",DocumentsMismatch=\\"DocumentsMismatch\\",Other=\\"Other\\"}
+        
+        
+        export interface UpgradeToBusinessUserInput {\\"address\\"?: string;\\"businessName\\"?: string;\\"businessShareType\\"?:  & (BusinessShareType);\\"businessType\\"?:  & (BusinessType);\\"city\\"?: string;\\"documents\\"?: DocumentInput[];\\"email\\"?: string;\\"faxNumber\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"logoFileUniqueId\\"?: string;\\"managerName\\"?: string;\\"managerPhoneNumber\\"?: string;\\"organizationName\\"?: string;\\"organizationNationalCode\\"?: string;\\"phoneNumber\\"?: string;\\"state\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'BusinessShareType' instead]
+ * @deprecated Use 'BusinessShareType' instead.
+ */
+\\"userIdentityType\\"?:  & (BusinessShareType);\\"webSiteUrl\\"?: string;}
+        
+        
+        export interface UserBankApiModel {
+/**
+ * 
+ * - Format: int32
+ */
+\\"bankId\\": number;\\"businessShareType\\": BusinessShareType;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;
+/**
+ * 
+ * [Deprecated, use 'BusinessShareType' instead]
+ * @deprecated Use 'BusinessShareType' instead.
+ */
+\\"identityType\\":  & (BusinessShareType);\\"isVisible\\": boolean;\\"status\\": IdentityStatus;\\"accountNumber\\"?: string;\\"bankLogo\\"?: string;\\"bankName\\"?: string;\\"businessShareTypeDisplay\\"?: string;\\"firstName\\"?: string;\\"lastName\\"?: string;\\"name\\"?: string;\\"rejectCause\\"?:  & (UserBankRejectCause);\\"rejectCauseDescription\\"?: string;\\"rejectCauseDisplay\\"?: string;\\"shebaNo\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'RejectCauseDescription' instead]
+ * @deprecated Use 'RejectCauseDescription' instead.
+ */
+\\"statusDescription\\"?: string;\\"statusDisplay\\"?: string;}
+        
+        
+        export interface UserBankChangeVisibilityInput {\\"isVisible\\"?: boolean;}
+        
+        
+        export type UserBankDetailApiModel =  & (UserBankApiModel & {\\"documents\\"?: DocumentApiModel[];\\"nationalCode\\"?: string;})
+        
+        
+        export interface UserBankInput {\\"accountNumber\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"bankId\\"?: number;\\"businessShareType\\"?:  & (BusinessShareType);\\"documents\\"?: DocumentInput[];\\"firstName\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'BusinessShareType' instead]
+ * @deprecated Use 'BusinessShareType' instead.
+ */
+\\"identityType\\"?:  & (BusinessShareType);\\"isVisible\\"?: boolean;\\"lastName\\"?: string;\\"name\\"?: string;\\"nationalCode\\"?: string;\\"shebaNo\\"?: string;}
+        
+        
+        export enum UserBankRejectCause {DocumentsLack=\\"DocumentsLack\\",DocumentsMismatch=\\"DocumentsMismatch\\",Etc=\\"Etc\\"}
+        
+        
+        export interface UserChangePasswordInput {\\"currentPassword\\"?: string;\\"newPassword\\"?: string;}
+        
+        
+        export type UserDetailQuery =  & (UserMeQuery & {\\"address\\"?: string;\\"city\\"?: string;\\"email\\"?: string;\\"introducedBySubDomain\\"?: string;\\"nationalCode\\"?: string;\\"phoneNumber\\"?: string;\\"state\\"?: string;})
+        
+        
+        export interface UserForgetPasswordInput {\\"phoneNumber\\"?: string;}
+        
+        
+        export enum UserIdentifierType {Default=\\"Default\\",PhoneNumber=\\"PhoneNumber\\",Email=\\"Email\\",CustomerNumber=\\"CustomerNumber\\",AccountNumber=\\"AccountNumber\\"}
+        
+        
+        export enum UserIdentityRejectCause {DocumentsLack=\\"DocumentsLack\\",DocumentsMismatch=\\"DocumentsMismatch\\",DocumentsRejected=\\"DocumentsRejected\\",Etc=\\"Etc\\"}
+        
+        
+        export interface UserIdentityRequestQuery {\\"status\\": IdentityStatus;
+/**
+ * 
+ * [Deprecated, use 'Status' instead]
+ * @deprecated Use 'Status' instead.
+ */
+\\"userIdentityRequestStatus\\":  & (IdentityStatus);\\"documents\\"?: DocumentApiModel[];\\"firstName\\"?: string;\\"lastName\\"?: string;\\"nationalCode\\"?: string;\\"rejectCause\\"?:  & (UserIdentityRejectCause);\\"rejectCauseDescription\\"?: string;\\"rejectCauseDisplay\\"?: string;\\"statusDisplay\\"?: string;
+/**
+ * 
+ * [Deprecated, use 'RejectCauseDescription' instead]
+ * @deprecated Use 'RejectCauseDescription' instead.
+ */
+\\"userIdentityRequestStatusDescription\\"?: string;}
+        
+        
+        export interface UserMeQuery {\\"identityStatus\\": IdentityStatus;\\"isBusinessUser\\": boolean;\\"isResellerUser\\": boolean;\\"isSubUser\\": boolean;
+/**
+ * 
+ * - Format: int64
+ */
+\\"shareCode\\": number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"birthDate\\"?: string;\\"birthDateDisplay\\"?: string;\\"businessName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"businessUserId\\"?: string;\\"gender\\"?:  & (Gender);\\"genderDisplay\\"?: string;\\"identityStatusDisplay\\"?: string;\\"profileImageLink\\"?: string;\\"referredBy\\"?: string;\\"title\\"?: string;}
+        
+        
+        export interface UserMinimalDto {
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"displayName\\"?: string;\\"positionTitle\\"?: string;}
+        
+        
+        export interface UserPluginApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"isActive\\": boolean;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"pluginConfig\\"?: string;\\"pluginName\\"?: string;\\"userDisplayName\\"?: string;}
+        
+        
+        export interface UserPluginDetailApiModel {
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"isActive\\": boolean;
+/**
+ * 
+ * - Format: int32
+ */
+\\"pluginId\\": number;
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;\\"pluginAmountCalculationExpression\\"?: string;\\"pluginConfig\\"?: string;\\"pluginLogoFileName\\"?: string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"pluginLogoFileUniqueId\\"?: string;\\"pluginLogoFileUrl\\"?: string;\\"pluginName\\"?: string;\\"properties\\"?: PluginPropertyApiModel[];\\"userDisplayName\\"?: string;}
+        
+        
+        export interface UserPluginTogggleApiModel {\\"isActive\\": boolean;}
+        
+        
+        export interface UserProfileAvatarInput {
+/**
+ * 
+ * - Format: guid
+ */
+\\"fileUniqueId\\"?: string;}
+        
+        
+        export interface UserProfileInput {\\"address\\"?: string;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"birthDate\\"?: string;\\"city\\"?: string;\\"email\\"?: string;\\"gender\\"?:  & (Gender);\\"state\\"?: string;}
+        
+        
+        export enum UserStatus {None=\\"None\\",NotVerified=\\"NotVerified\\",VerifiedButNotCompleted=\\"VerifiedButNotCompleted\\",Active=\\"Active\\",TemporaryBlocked=\\"TemporaryBlocked\\",AutoPasswordGenerated=\\"AutoPasswordGenerated\\"}
+        
+        
+        export interface UserVerifyForgetPasswordInput {\\"newPassword\\"?: string;\\"phoneNumber\\"?: string;\\"token\\"?: string;\\"verifyCode\\"?: string;}
+        
+        
+        export interface UserWorkspaceQuery {
+/**
+ * 
+ * - Format: guid
+ */
+\\"businessUserId\\": string;\\"workspaceType\\": WorkspaceType;\\"businessAvatarUrl\\"?: string;\\"businessName\\"?: string;\\"positionTitle\\"?: string;}
+        
+        
+        export interface VerifyPhoneNumberInput {
+/**
+ * 
+ * - Format: guid
+ */
+\\"userId\\": string;
+/**
+ * 
+ * - Format: guid
+ */
+\\"subDomainId\\"?: string;\\"token\\"?: string;\\"verifyCode\\"?: string;}
+        
+        
+        export enum VoucherOperationType {Unknown=\\"Unknown\\",EPayViaBankWithCommissionByPayer=\\"EPayViaBankWithCommissionByPayer\\",EPayViaBankWithCommissionByUser=\\"EPayViaBankWithCommissionByUser\\",EPayViaPSPWithCommissionByPayer=\\"EPayViaPSPWithCommissionByPayer\\",EPayViaPSPWithCommissionByUser=\\"EPayViaPSPWithCommissionByUser\\",EPayViaWalletWithCommissionByPayer=\\"EPayViaWalletWithCommissionByPayer\\",EPayViaWalletWithCommissionByUser=\\"EPayViaWalletWithCommissionByUser\\",TransferMoney=\\"TransferMoney\\",ChargeWallet=\\"ChargeWallet\\",ServiceBill=\\"ServiceBill\\",ServiceMobileCharge=\\"ServiceMobileCharge\\",POSViaBank=\\"POSViaBank\\",POSViaWallet=\\"POSViaWallet\\",ShareAndBlockRequest=\\"ShareAndBlockRequest\\",ShareRequest=\\"ShareRequest\\",SettlementAuto=\\"SettlementAuto\\",SettlementManual=\\"SettlementManual\\",SettlementSuspected=\\"SettlementSuspected\\",GroupTransferMoney=\\"GroupTransferMoney\\",ShareAndUnblock=\\"ShareAndUnblock\\",RefundWithSystemPayer=\\"RefundWithSystemPayer\\",RefundWithAnonymousPayer=\\"RefundWithAnonymousPayer\\",PayCommand=\\"PayCommand\\",GiftForReferrer=\\"GiftForReferrer\\",GiftForNoCommissionRemain=\\"GiftForNoCommissionRemain\\",Sepid=\\"Sepid\\",BatchTransferItem=\\"BatchTransferItem\\",AbstractProviderSynchronization=\\"AbstractProviderSynchronization\\",BlockchainWithdrawInternalTransfer=\\"BlockchainWithdrawInternalTransfer\\",BlockchainWithdrawUserWallet=\\"BlockchainWithdrawUserWallet\\",BlockchainIncomingTransaction=\\"BlockchainIncomingTransaction\\",BlockchainWithdrawUserWalletOnChain=\\"BlockchainWithdrawUserWalletOnChain\\"}
+        
+        
+        export type WalletDetailApiModel =  & (WalletDisplayApiModel & {\\"notificationEnabled\\": boolean;
+/**
+ * 
+ * - Format: int32
+ */
+\\"permittedSubuserCount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"posPaidCount\\": number;
+/**
+ * 
+ * - Format: int32
+ */
+\\"posScanCount\\": number;\\"accountQrCodeUrl\\"?: string;\\"actionPolicies\\"?: CommissionPolicyApiModel[];\\"posLinkUrl\\"?: string;})
+        
+        
+        export interface WalletDisplayApiModel {\\"automaticSettlement\\": boolean;\\"getComissionFromPayer\\": boolean;
+/**
+ * 
+ * - Format: int64
+ */
+\\"id\\": number;\\"isActive\\": boolean;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"realBalance\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"totalBalance\\": number;\\"directUserBankAccountNumber\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"directUserBankBankId\\"?: number;\\"directUserBankBankName\\"?: string;\\"directUserBankShebaNumber\\"?: string;\\"intermediateUserBankAccountNumber\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"intermediateUserBankBankId\\"?: number;\\"intermediateUserBankBankName\\"?: string;\\"intermediateUserBankShebaNumber\\"?: string;\\"number\\"?: string;
+/**
+ * 
+ * - Format: int32
+ */
+\\"relatedUserAccountIndex\\"?: number;\\"title\\"?: string;}
+        
+        
+        export interface WalletReceiptApiModel {
+/**
+ * 
+ * - Format: decimal
+ */
+\\"amount\\": number;
+/**
+ * 
+ * - Format: decimal
+ */
+\\"commissionAmount\\": number;
+/**
+ * 
+ * - Format: date-time
+ */
+\\"createDate\\": string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"payerAccountId\\": number;\\"callbackUrl\\"?: string;\\"creatorUserAvatarUrl\\"?: string;\\"creatorUserDisplayName\\"?: string;\\"description\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"operationId\\"?: number;\\"payerAccountName\\"?: string;\\"payerAccountNumber\\"?: string;\\"sharerUrl\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"targetAccountId\\"?: number;\\"targetAccountNumber\\"?: string;\\"targetUserAvatarUrl\\"?: string;\\"targetUserDisplayName\\"?: string;
+/**
+ * 
+ * - Format: int64
+ */
+\\"voucherId\\"?: number;}
+        
+        
+        export enum WorkspaceType {User=\\"User\\",SubUser=\\"SubUser\\"}
+        "
+`;

--- a/__tests__/main/excludes.test.mjs
+++ b/__tests__/main/excludes.test.mjs
@@ -1,0 +1,39 @@
+import { generator } from "../../lib/javascript/generator.mjs";
+import swaggerJson from "./swagger.json";
+
+describe("excludes post methods", () => {
+  const { code, hooks, type } = generator(swaggerJson, {
+    dir: "",
+    reactHooks: true,
+    excludes: ["^post"],
+  });
+
+  it("generate Code", () => {
+    expect(code).toMatchSnapshot();
+  });
+  it("generate hooks", () => {
+    expect(hooks).toMatchSnapshot();
+  });
+  it("generate type", () => {
+    expect(type).toMatchSnapshot();
+  });
+});
+
+describe("only includes get methods does not ends with Id", () => {
+  const { code, hooks, type } = generator(swaggerJson, {
+    dir: "",
+    reactHooks: true,
+    includes: ["^get"],
+    excludes: ["Id$"],
+  });
+
+  it("generate Code", () => {
+    expect(code).toMatchSnapshot();
+  });
+  it("generate hooks", () => {
+    expect(hooks).toMatchSnapshot();
+  });
+  it("generate type", () => {
+    expect(type).toMatchSnapshot();
+  });
+});

--- a/__tests__/main/includes.test.mjs
+++ b/__tests__/main/includes.test.mjs
@@ -1,0 +1,38 @@
+import { generator } from "../../lib/javascript/generator.mjs";
+import swaggerJson from "./swagger.json";
+
+describe("only includes get methods", () => {
+  const { code, hooks, type } = generator(swaggerJson, {
+    dir: "",
+    reactHooks: true,
+    includes: ["^get"],
+  });
+
+  it("generate Code", () => {
+    expect(code).toMatchSnapshot();
+  });
+  it("generate hooks", () => {
+    expect(hooks).toMatchSnapshot();
+  });
+  it("generate type", () => {
+    expect(type).toMatchSnapshot();
+  });
+});
+
+describe("only includes methods ends with Id", () => {
+  const { code, hooks, type } = generator(swaggerJson, {
+    dir: "",
+    reactHooks: true,
+    includes: ["Id$"],
+  });
+
+  it("generate Code", () => {
+    expect(code).toMatchSnapshot();
+  });
+  it("generate hooks", () => {
+    expect(hooks).toMatchSnapshot();
+  });
+  it("generate type", () => {
+    expect(type).toMatchSnapshot();
+  });
+});

--- a/readme.md
+++ b/readme.md
@@ -96,19 +96,20 @@ For Example:
 | `local`              | false                  | update swagger with local swagger.json located in your dir folder. add it to your config file or run it with cli `$ yarn swag-ts --local`                                                                                                      |
 | `kotlinPackage`      | Required (Only kotlin) | package name of source dir                                                                                                                                                                                                                     |
 | `generateEnumAsType` | false                  |
+| `includes`           | []                     | A list of regex patterns that specify which APIs to include based on matching method names                                                                                                                                                     |
+| `excludes`           | []                     | A list of regex patterns that specify which APIs to exclude based on matching method names                                                                                                                                                     |
 
 - `enum ReferralStatus {Successed="Successed","Error"="Error"} `
 - `type ReferralStatus="Successed" | "Error"; // generateEnumAsType = true `
-  |
 
 # CLI Options
 
-| [`Key`]  | [`default`]             | Comment                                                                                                                                            |
-| -------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `local`  | false                   | update swagger with local swagger.json located in your dir folder. add it to your config file or run it with cli `$ yarn swag-ts --local`          |
-| `branch` | Current Branch          | to generate swagger for develop run `yarn swag-ts --branch=develop` or your branch name should be `develop` or a branch which created from develop |
-| `config` | "./swagger.config.json" | A path for config file location <br> - `yarn swag-ts --config=./config` path is related for "swagger.config.json" file in config folder <br> - `yarn swag-ts --config=./config/myswagger.json` you could change config file name <br> - `yarn swag-ts --config=/user/hosseinmd/desktop/config/swagger.config.json` you could add absolute path
-  |
+| [`Key`]  | [`default`]             | Comment                                                                                                                                                                                                                                                                                                                                        |
+| -------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `local`  | false                   | update swagger with local swagger.json located in your dir folder. add it to your config file or run it with cli `$ yarn swag-ts --local`                                                                                                                                                                                                      |
+| `branch` | Current Branch          | to generate swagger for develop run `yarn swag-ts --branch=develop` or your branch name should be `develop` or a branch which created from develop                                                                                                                                                                                             |
+| `config` | "./swagger.config.json" | A path for config file location <br> - `yarn swag-ts --config=./config` path is related for "swagger.config.json" file in config folder <br> - `yarn swag-ts --config=./config/myswagger.json` you could change config file name <br> - `yarn swag-ts --config=/user/hosseinmd/desktop/config/swagger.config.json` you could add absolute path |
+|          |
 
 ## Config
 

--- a/src/javascript/generator.mts
+++ b/src/javascript/generator.mts
@@ -56,7 +56,7 @@ function generator(
     (pattern) => new RegExp(pattern),
   );
 
-  function getModifiedPathValue(endPoint: string, value: PathItem) {
+  function getFilteredMethods(endPoint: string, value: PathItem) {
     return Object.entries(value).filter(
       ([method, options]: [string, SwaggerRequest]) => {
         const { operationId } = options;
@@ -83,7 +83,7 @@ function generator(
   try {
     Object.entries(input.paths).forEach(([endPoint, value]) => {
       const parametersExtended = value.parameters as Parameter[] | undefined;
-      getModifiedPathValue(endPoint, value).forEach(
+      getFilteredMethods(endPoint, value).forEach(
         ([method, options]: [string, SwaggerRequest]) => {
           if (method === "parameters") {
             return;

--- a/src/javascript/generator.mts
+++ b/src/javascript/generator.mts
@@ -17,6 +17,7 @@ import type {
   Parameter,
   ConstantsAST,
   Method,
+  PathItem,
 } from "../types.mjs";
 import { generateApis } from "./generateApis.mjs";
 import { generateTypes } from "./generateTypes.mjs";
@@ -48,10 +49,41 @@ function generator(
     return name;
   }
 
+  const includes = (config.includes || []).map(
+    (pattern) => new RegExp(pattern),
+  );
+  const excludes = (config.excludes || []).map(
+    (pattern) => new RegExp(pattern),
+  );
+
+  function getModifiedPathValue(endPoint: string, value: PathItem) {
+    return Object.entries(value).filter(
+      ([method, options]: [string, SwaggerRequest]) => {
+        const { operationId } = options;
+
+        const serviceName = generateServiceName(
+          endPoint,
+          method,
+          operationId,
+          config,
+        );
+
+        const matchesInclude =
+          !includes.length || includes.some((regex) => regex.test(serviceName));
+
+        const matchesExclude = excludes.some((regex) =>
+          regex.test(serviceName),
+        );
+
+        return matchesInclude && !matchesExclude;
+      },
+    );
+  }
+
   try {
     Object.entries(input.paths).forEach(([endPoint, value]) => {
       const parametersExtended = value.parameters as Parameter[] | undefined;
-      Object.entries(value).forEach(
+      getModifiedPathValue(endPoint, value).forEach(
         ([method, options]: [string, SwaggerRequest]) => {
           if (method === "parameters") {
             return;

--- a/src/types.mts
+++ b/src/types.mts
@@ -263,6 +263,8 @@ export interface FileConfig {
   /** Default is false */
   keepJson?: boolean;
   reactHooks?: boolean;
+  includes?: string[];
+  excludes?: string[];
   useQuery?: string[];
   useInfiniteQuery?: string[];
   mock?: string;


### PR DESCRIPTION
Add two new configuration options, "includes" and "excludes", both of which can be arrays of string regex patterns. These options are used to filter the services based on their service names. This feature is particularly useful when you need to include or exclude specific services from a Swagger endpoint.

for example this swagger config, only generates services that their service name starts with "get":

```
{
  "url": "https://petstore.swagger.io/v2/swagger.json",
  "reactHooks": true,
  "dir": "./src/services",
  "generateEnumAsType": true,
  "includes": ["^get"]
}
```