### PR TITLE
Fix generation of Integer enums

### DIFF
--- a/src/javascript/generateTypes.mts
+++ b/src/javascript/generateTypes.mts
@@ -167,7 +167,7 @@ function generateEnumAsEnum(
 ): string {
   const entries = enumValues.map((value, index) => {
     const key = enumNames?.[index] ?? JSON.stringify(value);
-    return `${key}=${JSON.stringify(value)}`;
+    return `"${key.replace(/"/g, "")}"=${JSON.stringify(value)}`;
   });
 
   return `export enum ${name} {${entries.join(",")}}`;


### PR DESCRIPTION
Enums with integer keys gives an error during generation.

export enum VatRatioChoices {0=0,1=1,8=8,10=10,18=18,20=20}
SyntaxError: An enum member cannot have a numeric name.  
